### PR TITLE
Add basic Next.js homepage

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from 'next/router'
+import en from '../en.json'
+import ru from '../ru.json'
+import it from '../it.json'
+
+const translations: Record<string, { title: string; subtitle: string }> = { en, ru, it }
+
+export default function Home() {
+  const { locale } = useRouter()
+  const t = translations[locale ?? 'en'] || translations.en
+  return (
+    <main style={{ textAlign: 'center', marginTop: '20vh' }}>
+      <h1>{t.title}</h1>
+      <p>{t.subtitle}</p>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- create minimal `index.tsx` page that loads translations
- add `next-env.d.ts` for TypeScript support

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68757c2bfe90832c93b4d13154a39c0a