### PR TITLE
Fix 404 by removing stale rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+package-lock.json

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "rewrites": [
-    {
-      "source": "/",
-      "destination": "/index"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## Summary
- remove bad root rewrite from `vercel.json`
- add `.gitignore` to ignore build artifacts

The website on Vercel was returning a 404 due to rewriting `/` to `/index`. Removing the rewrite allows Next.js to serve the homepage normally.

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875eb2d7e34832cbc3ad0bad385440b