### PR TITLE
Add favicon link in global app

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app';
 import { appWithTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import Head from 'next/head';
 import '../styles/globals.css';
 import nextI18NextConfig from '../../next-i18next.config';
 
@@ -20,7 +21,14 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
   }, [router]);
 
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Head>
+        <link rel="icon" href="/fav.ico" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 }
 
 export default appWithTranslation(MyApp, nextI18NextConfig);


### PR DESCRIPTION
## Summary
- add `Head` component in `_app`
- include `/fav.ico` favicon

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877520a2928832c86e0b72bbe0e6c1a