### PR TITLE
Add favicon support on localized routes

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   i18n: {
     defaultLocale: 'en',
-    locales: ['en','ru','it','es','zh','pt-BR','fr','de','ja','ko','uk','pl','tr','ar','hi','nl','el','id','th'],
+    // Limit supported languages to the ones we actually provide translations
+    // for and want to expose in the UI. This keeps routing simpler and
+    // matches the expected languages from the docs.
+    locales: ['en', 'it', 'ru'],
   },
 };


### PR DESCRIPTION
## Summary
- ensure locales list only includes `en`, `it` and `ru`
- favicon in `_app.tsx` already ensures absolute path for i18n routes

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68775bb10144832ca17f39a206aa8b57