### PR TITLE
Добавлены favicon и манифест в Head

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -24,7 +24,14 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
-        <link rel="icon" href="/fav.ico" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+        <link rel="manifest" href="/site.webmanifest" />
+        <link rel="shortcut icon" href="/favicon.ico" />
+        <meta name="msapplication-TileColor" content="#ffffff" />
+        <meta name="msapplication-TileImage" content="/mstile-150x150.png" />
+        <meta name="theme-color" content="#ffffff" />
       </Head>
       <Component {...pageProps} />
     </>


### PR DESCRIPTION
## Summary
- расширенные favicon и link to site.webmanifest добавлены в `src/pages/_app.tsx`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68775d8ce97c832c9edd41c8b7d2024f