### PR TITLE
Fix missing translations by removing rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,2 @@
 {
-  "rewrites": [
-    {
-      "source": "/",
-      "destination": "/index"
-    }
-  ]
 }


### PR DESCRIPTION
## Summary
- remove root rewrite from `vercel.json` so Vercel can detect locales

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877971b1320832cbcfdfd7236be8143