### PR TITLE
Fix Cornetto Clicker asset paths

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/cornettoclicker',
+        destination: '/cornettoclicker/index.html',
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/public/cornettoclicker/index.html
+++ b/public/cornettoclicker/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Cornetto Clicker</title>
-<link rel="stylesheet" href="style.css">
+    <base href="/cornettoclicker/">
+<link rel="stylesheet" href="/cornettoclicker/style.css">
 </head>
 <body>
 <div id="start-screen" class="screen active">
@@ -28,6 +29,6 @@
   <button id="restart-btn">Restart</button>
   <button id="share-btn">Поделиться</button>
 </div>
-<script src="main.js"></script>
+<script src="/cornettoclicker/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- set a `<base>` tag and absolute links in `public/cornettoclicker/index.html`
- add rewrite rule in `next.config.js` so `/cornettoclicker` serves the static game

## Testing
- `npm run build`
- `npm run start` & curl `/cornettoclicker`

------
https://chatgpt.com/codex/tasks/task_e_6886a3c14aa4832c953e5dd0939ab981