### PR TITLE
Add hot cup catcher gameplay

### DIFF
--- a/public/cornettoclicker/index.html
+++ b/public/cornettoclicker/index.html
@@ -11,14 +11,16 @@
 <div id="start-screen" class="screen active">
   <button id="start-btn">Начать игру</button>
 </div>
-<div id="game-screen" class="screen">
-  <div id="hud">
-    <div>🥐 Собрано: <span id="score">0</span></div>
-    <div>❌ Пропущено: <span id="missed">0</span>/10</div>
-    <div>⏱ Время: <span id="timer">0</span> c</div>
+  <div id="game-screen" class="screen">
+    <div id="hud">
+      <div>🥐 Собрано: <span id="score">0</span></div>
+      <div>❌ Пропущено: <span id="missed">0</span>/10</div>
+      <div>⏱ Время: <span id="timer">0</span> c</div>
+    </div>
+  <div id="game-area">
+    <div id="player">☕</div>
   </div>
-  <div id="game-area"></div>
-</div>
+  </div>
 <div id="end-screen" class="screen">
   <div id="end-message"></div>
   <div id="final-croissant"></div>

--- a/public/cornettoclicker/style.css
+++ b/public/cornettoclicker/style.css
@@ -29,8 +29,17 @@ body {
 .object {
   position: absolute;
   font-size: 2em;
-  cursor: pointer;
   user-select: none;
+  pointer-events: none;
+}
+#player {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 3em;
+  user-select: none;
+  pointer-events: none;
 }
 #final-croissant {
   font-size: 2em;


### PR DESCRIPTION
## Summary
- create hot cup player element
- allow arrow keys and touch to control the cup
- check for collisions between falling items and the cup
- only croissants increase score, fire triggers game over

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68871ee50be4832cb7e3defee485494c