### PR TITLE
Fix background audio cleanup

### DIFF
--- a/public/cornettoclicker/main.js
+++ b/public/cornettoclicker/main.js
@@ -200,6 +200,17 @@ function stopGame() {
   clearInterval(intervalId);
   clearInterval(timerId);
   clearInterval(percussionInterval);
+  if (bgOsc) {
+    try {
+      bgOsc.stop();
+    } catch (e) {
+      console.error(e);
+    }
+    bgOsc.disconnect();
+    bgGain.disconnect();
+    bgOsc = null;
+    audioStarted = false;
+  }
   document.querySelectorAll('.object').forEach(o => o.remove());
   gameArea.removeEventListener('pointermove', pointerMove);
   document.removeEventListener('keydown', keyMove);


### PR DESCRIPTION
## Summary
- stop & disconnect oscillator on game end so background music stops

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68873fcbe36c832c8bf430bb3f5ccc4a