### PR TITLE
Configure cornettoclicker rewrites via vercel.json

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,18 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  async rewrites() {
-    return [
-      {
-        source: '/cornettoclicker',
-        destination: '/cornettoclicker/index.html',
-      },
-      {
-        source: '/cornettoclicker/',
-        destination: '/cornettoclicker/index.html',
-      },
-    ];
-  },
+  // Remove cornettoclicker rewrites from here
 };
 
 module.exports = nextConfig;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "rewrites": [
+    {
+      "source": "/cornettoclicker",
+      "destination": "/cornettoclicker/index.html"
+    },
+    {
+      "source": "/cornettoclicker/",
+      "destination": "/cornettoclicker/index.html"
+    },
+    {
+      "source": "/cornettoclicker/:path*",
+      "destination": "/cornettoclicker/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- move static rewrites for cornettoclicker to `vercel.json`
- clean up `next.config.js` rewrites configuration

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68875f4427a8832cb232b249763eae60