### PR TITLE
Use pixel font globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-black text-primary font-sans;
+  @apply bg-black text-primary font-pixel;
 }


### PR DESCRIPTION
## Summary
- use pixel font for body text for a retro look

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68879bf85ecc832c940aea544b2d2587