### PR TITLE
Add image upload API

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "formidable": "^3.5.4",
     "next": "14.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { IncomingForm, File } from 'formidable'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+}
+
+interface JsonResponse {
+  success: boolean
+  fileUrl?: string
+  message?: string
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<JsonResponse>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ success: false, message: 'Method not allowed' })
+  }
+
+  const form = new IncomingForm({ maxFileSize: 20 * 1024 * 1024 })
+
+  try {
+    const [fields, files] = await form.parse(req)
+    const uploaded = files.file as File | File[] | undefined
+
+    if (!uploaded) {
+      return res.status(400).json({ success: false, message: 'File is required' })
+    }
+    const file = Array.isArray(uploaded) ? uploaded[0] : uploaded
+
+    if (!file.mimetype || !file.mimetype.startsWith('image/')) {
+      return res.status(400).json({ success: false, message: 'Only images are allowed' })
+    }
+
+    const now = new Date()
+    const dateStr = now.toISOString().slice(0, 10)
+    const uploadDir = path.join(process.cwd(), 'public', 'uploads', dateStr)
+    await fs.mkdir(uploadDir, { recursive: true })
+
+    const timeStr = now
+      .toTimeString()
+      .split(' ')[0]
+      .replace(/:/g, '-')
+    const filename = `IMG_${timeStr}.jpg`
+    const filepath = path.join(uploadDir, filename)
+
+    await fs.rename(file.filepath, filepath)
+
+    const fileUrl = `/uploads/${dateStr}/${filename}`
+    return res.status(200).json({ success: true, fileUrl })
+  } catch (err: any) {
+    const message = err instanceof Error ? err.message : 'Unexpected error'
+    return res.status(500).json({ success: false, message })
+  }
+}


### PR DESCRIPTION
## Summary
- add `formidable` dependency
- implement `pages/api/upload.ts` to accept image uploads and store them in `public/uploads`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888a04996d0832ca3e17582eb08c1f8