### PR TITLE
Fix Pac-Man ghost movement bounds

### DIFF
--- a/app/PacMan/page.tsx
+++ b/app/PacMan/page.tsx
@@ -128,7 +128,18 @@ export default function PacManPage() {
         { x: 0, y: 1 },
         { x: 0, y: -1 },
       ];
-      const valid = dirs.filter((d) => map[gy + d.y][gx + d.x] !== 1);
+      const valid = dirs.filter((d) => {
+        const nx = gx + d.x;
+        const ny = gy + d.y;
+        return (
+          nx >= 0 &&
+          nx < cols &&
+          ny >= 0 &&
+          ny < rows &&
+          map[ny][nx] !== 1
+        );
+      });
+      if (valid.length === 0) return { x: 0, y: 0 };
       return valid[Math.floor(Math.random() * valid.length)];
     };
 


### PR DESCRIPTION
## Summary
- guard ghost movement logic against out‑of‑bounds access
- return `{x:0, y:0}` if no valid direction exists

## Testing
- `npm test`
- `npm run build` *(fails to download fonts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6889eec934e4832ca7b1408df2c1122a