### PR TITLE
Update Cornetto Clicker logo

### DIFF
--- a/app/cornettoclicker-landing/page.tsx
+++ b/app/cornettoclicker-landing/page.tsx
@@ -104,7 +104,7 @@ export default function CornettoLanding() {
       </Head>
       <div className="landing-container">
       <header className="pixel-header" aria-label="Main navigation">
-        <Image src="/cornettoclicker/logo.svg" alt="🥐 Cornetto Clicker" width={64} height={64} className="pixel-logo" />
+        <Image src="/logo/Azumbo%20Logo%20no%20background%20small%20size.jpeg" alt="🥐 Cornetto Clicker" width={64} height={64} className="pixel-logo" />
         <nav className="pixel-nav">
           <a href="#game" data-i18n="nav.game"></a>
           <a href="#biz" data-i18n="nav.biz"></a>

--- a/public/cornettoclicker/index.html
+++ b/public/cornettoclicker/index.html
@@ -11,7 +11,7 @@
 <body>
   <div id="overlay"></div>
   <header class="pixel-header">
-    <img src="logo.svg" alt="\ud83e\udd50 Cornetto Clicker" class="pixel-logo" aria-label="Cornetto Clicker logo">
+    <img src="/logo/Azumbo%20Logo%20no%20background%20small%20size.jpeg" alt="\ud83e\udd50 Cornetto Clicker" class="pixel-logo" aria-label="Cornetto Clicker logo">
     <nav class="pixel-nav">
       <a href="#game" data-i18n="nav.game">About Game</a>
       <a href="#biz" data-i18n="nav.biz">For Business</a>


### PR DESCRIPTION
## Summary
- switch Cornetto Clicker pages to use the Azumbo logo JPEG

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889fbbfb4ec832cb061aea3fcfa8bbf