### PR TITLE
Add mobile controls to PacMan

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,12 @@
   --font-press-start: 'Press Start 2P', cursive;
 }
 
+canvas {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1 / 1;
+}
+
 .pixel-container {
     font-family: 'Press Start 2P', cursive;
     background: #1a2980;
@@ -44,9 +50,27 @@
 @media (max-width: 768px) {
     .mobile-controls {
         display: flex;
-        justify-content: space-around;
+        justify-content: center;
         margin-top: 20px;
+        width: 100%;
+        position: fixed;
+        bottom: 20px;
     }
+
+    .d-pad {
+        display: inline-grid;
+        grid-template-areas:
+            '. up .'
+            'left . right'
+            '. down .';
+        gap: 10px;
+        margin-right: 20px;
+    }
+
+    .d-pad button:nth-child(1) { grid-area: up; }
+    .d-pad button:nth-child(2) { grid-area: left; }
+    .d-pad button:nth-child(3) { grid-area: down; }
+    .d-pad button:nth-child(4) { grid-area: right; }
 
     .mobile-controls button {
         width: 80px;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <head>
         <meta charSet="UTF-8" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+        />
       </head>
       <body className={pressStart.className}>
         <SoundToggle />


### PR DESCRIPTION
## Summary
- enable viewport meta tag for responsive sizing
- add canvas scaling and touch control handlers to PacMan
- create on-screen directional pad via CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b7e1ebf38832cbddaa69e1233adf6