### PR TITLE
Add static policy pages for Petonauta Afozio

### DIFF
--- a/public/petonauta/privacy.html
+++ b/public/petonauta/privacy.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy</title>
+</head>
+<body style="font-family:sans-serif; margin:20px;">
+  <h1>Privacy Policy</h1>
+  <p>This Privacy Policy explains how <strong>AZUMBO</strong> collects and uses information when you play <strong>Petonauta Afozio</strong> (the "Game").</p>
+  <h2>1. Personal Data</h2>
+  <p>The Game does not collect any personal data without your consent. You may choose to share content via TikTok Share Kit, in which case the policies and terms of TikTok apply.</p>
+  <h2>2. Game Statistics</h2>
+  <p>We may collect anonymous information such as gameplay attempts or crash reports to improve the Game. This data does not identify you personally.</p>
+  <h2>3. Data Sharing</h2>
+  <p>Your data is not sold or shared with third parties. Information collected through TikTok Share Kit is governed by TikTok&apos;s policies.</p>
+  <h2>4. Children&apos;s Privacy</h2>
+  <p>The Game is intended for a general audience but requires parental consent for players under 13 years old in accordance with COPPA. We process personal data in compliance with GDPR.</p>
+  <h2>5. Contact Us</h2>
+  <p>If you have questions about this policy, please contact us at <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.</p>
+  <p style="margin-top:40px;"><em>Last updated: July 31, 2025</em></p>
+</body>
+</html>

--- a/public/petonauta/terms.html
+++ b/public/petonauta/terms.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Terms of Service</title>
+</head>
+<body style="font-family:sans-serif; margin:20px;">
+  <h1>Terms of Service</h1>
+  <p>These Terms of Service govern your use of the game <strong>Petonauta Afozio</strong> (the "Game") developed by <strong>AZUMBO</strong>. By installing or using the Game you agree to these Terms.</p>
+  <h2>1. Use of the Game</h2>
+  <p>You may use the Game for your personal entertainment only. You must not use the Game for any destructive, unlawful, or fraudulent purpose. All rights not expressly granted to you are reserved by AZUMBO.</p>
+  <h2>2. No Warranties</h2>
+  <p>The Game is provided "as is" without warranties of any kind, whether express or implied. AZUMBO does not guarantee that the Game will be error-free or that access will be uninterrupted.</p>
+  <h2>3. Limitation of Liability</h2>
+  <p>To the fullest extent permitted by law, AZUMBO will not be liable for any damages arising from your use of the Game.</p>
+  <h2>4. Age Requirements</h2>
+  <p>The Game is not directed to children under the age of 13. If you are under 13 years old, you must obtain permission from a parent or guardian to play the Game, in compliance with the U.S. Children&apos;s Online Privacy Protection Act (COPPA).</p>
+  <h2>5. Governing Law</h2>
+  <p>These Terms are governed by the laws of the European Union and Italy, without regard to its conflict of laws principles.</p>
+  <p>If any provision of these Terms is found unenforceable, the remaining provisions shall remain in full force.</p>
+  <p style="margin-top:40px;">For support, please contact: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+  <p><em>Last updated: July 31, 2025</em></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `terms.html` and `privacy.html` under `/public/petonauta`
- these pages describe terms of service and privacy policy for the game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b8aeee500832caba21d066747e010