### PR TITLE
Fix responsive sizing in IphoneWrapper

### DIFF
--- a/components/IphoneWrapper.js
+++ b/components/IphoneWrapper.js
@@ -4,15 +4,17 @@ export default function IphoneWrapper({ children }) {
     <div
       style={{
         background: `url(/cornettoclicker/iphone-frame.png) no-repeat center/contain`,
-        width: '430px',
-        height: '932px',
+        width: '100%',
+        height: '100vh',
+        maxWidth: '430px',
+        maxHeight: '932px',
         position: 'relative',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
       }}
     >
-      <div style={{ width: '86%', height: '93%' }}>{children}</div>
+      <div style={{ width: '100%', height: '100%' }}>{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make the iPhone frame responsive with `width: 100%` and `height: 100vh`
- ensure inner content fills the frame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be28dceec832ca8fcf8682f39c538