### PR TITLE
Fix Pac-Man cleanup

### DIFF
--- a/app/PacMan/page.tsx
+++ b/app/PacMan/page.tsx
@@ -217,6 +217,7 @@ export default function PacManPage() {
     };
 
     let last = performance.now();
+    let frameId: number;
     const loop = () => {
       const now = performance.now();
       const dt = (now - last) / 1000;
@@ -224,15 +225,17 @@ export default function PacManPage() {
       if (status === 'play') {
         update(dt);
         draw();
-        requestAnimationFrame(loop);
+        frameId = requestAnimationFrame(loop);
       }
     };
-    requestAnimationFrame(loop);
+    frameId = requestAnimationFrame(loop);
 
     return () => {
       document.removeEventListener('keydown', keydown);
       document.removeEventListener('keyup', keyup);
       if (nextTimeout) clearTimeout(nextTimeout);
+      cancelAnimationFrame(frameId);
+      pacmanAudio.stopWaka();
     };
   }, [status, level]);
 


### PR DESCRIPTION
## Summary
- cancel `requestAnimationFrame` when unmounting Pac-Man
- stop waka audio on unmount

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be5a89a24832c89987fdf085140f7