### PR TITLE
Fix PacMan ghost randomDir bounds check

### DIFF
--- a/app/PacMan/page.tsx
+++ b/app/PacMan/page.tsx
@@ -128,18 +128,20 @@ export default function PacManPage() {
         { x: 0, y: 1 },
         { x: 0, y: -1 },
       ];
+
       const valid = dirs.filter((d) => {
         const nx = gx + d.x;
         const ny = gy + d.y;
-        return (
-          nx >= 0 &&
-          nx < cols &&
-          ny >= 0 &&
-          ny < rows &&
-          map[ny][nx] !== 1
-        );
+
+        if (nx < 0 || nx >= cols || ny < 0 || ny >= rows) return false;
+
+        return map[ny][nx] !== 1;
       });
-      if (valid.length === 0) return { x: 0, y: 0 };
+
+      if (valid.length === 0) {
+        return { x: 0, y: 0 }; // fallback if no valid moves
+      }
+
       return valid[Math.floor(Math.random() * valid.length)];
     };
 


### PR DESCRIPTION
## Summary
- avoid out-of-bounds array lookups when picking ghost directions in PacMan

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be5aab1b8832cb7c9d02a54c1b5cf