### PR TITLE
Add Petonauta landing and improve home language detection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,19 @@
 'use client';
 import { useRouter } from 'next/navigation';
 import { gameConfig, localization } from '../lib/config';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function LanguageSelect() {
   const router = useRouter();
-  const [lang] = useState(gameConfig.defaultLanguage);
+  const [lang, setLang] = useState(gameConfig.defaultLanguage);
   const t = localization;
+
+  useEffect(() => {
+    const browserLang = navigator.language.slice(0, 2);
+    if (gameConfig.languages.includes(browserLang)) {
+      setLang(browserLang);
+    }
+  }, []);
 
   const selectLang = (l: string) => {
     localStorage.setItem('lang', l);

--- a/app/petonauta-landing/page.tsx
+++ b/app/petonauta-landing/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+import Head from 'next/head';
+import Link from 'next/link';
+import './style.css';
+
+export default function PetonautaLanding() {
+  return (
+    <>
+      <Head>
+        <title>Petonauta Afozio</title>
+        <meta name="description" content="Petonauta Afozio game landing" />
+      </Head>
+      <div className="petonauta-landing">
+        <h1>🚀 Petonauta Afozio</h1>
+        <p>Join the cosmic adventure – coming soon!</p>
+        <footer>
+          <Link href="/petonauta/privacy.html">Privacy Policy</Link>
+          <span> | </span>
+          <Link href="/petonauta/terms.html">Terms of Service</Link>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/app/petonauta-landing/style.css
+++ b/app/petonauta-landing/style.css
@@ -1,0 +1,20 @@
+.petonauta-landing {
+  font-family: 'Press Start 2P', cursive;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: #000;
+  color: #fff;
+  text-align: center;
+}
+
+.petonauta-landing footer {
+  margin-top: 40px;
+}
+
+.petonauta-landing a {
+  color: #0ff;
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- detect browser language on home page for localized greeting
- introduce simple Petonauta landing with links to privacy and terms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f6c5097b8832c89b1c0c4b9c3cb5f