### PR TITLE
Add multilingual legal pages for CornettoClicker

### DIFF
--- a/app/cornettoclicker/privacy/metadata.ts
+++ b/app/cornettoclicker/privacy/metadata.ts
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '[EN/IT/RU] Privacy Policy — AZUMBO | Mr Cup Cornetto',
+  description: 'Privacy Policy for Mr Cup Cornetto by AZUMBO (GDPR-ready).',
+  alternates: {
+    canonical: 'https://azumbo.com/cornettoclicker/privacy'
+  },
+  openGraph: {
+    title: '[EN/IT/RU] Privacy Policy — AZUMBO | Mr Cup Cornetto',
+    description: 'Privacy Policy for Mr Cup Cornetto by AZUMBO (GDPR-ready).',
+    url: 'https://azumbo.com/cornettoclicker/privacy'
+  },
+  twitter: {
+    card: 'summary',
+    title: '[EN/IT/RU] Privacy Policy — AZUMBO | Mr Cup Cornetto',
+    description: 'Privacy Policy for Mr Cup Cornetto by AZUMBO (GDPR-ready).'
+  },
+  robots: {
+    index: true,
+    follow: true
+  }
+};
+
+export default metadata;

--- a/app/cornettoclicker/privacy/page.tsx
+++ b/app/cornettoclicker/privacy/page.tsx
@@ -1,0 +1,556 @@
+'use client';
+
+import { useState } from 'react';
+import LanguageSwitch, { Language } from '../../../components/LanguageSwitch';
+import type { ReactNode } from 'react';
+
+interface Section {
+  id: string;
+  title: string;
+  content: ReactNode;
+}
+
+interface PageContent {
+  heading: string;
+  metaTitle: string;
+  metaDescription: string;
+  sections: Section[];
+  lastUpdated: string;
+}
+
+const content: Record<Language, PageContent> = {
+  en: {
+    heading: 'Privacy Policy',
+    metaTitle: 'Privacy Policy — AZUMBO | Mr Cup Cornetto',
+    metaDescription: 'Privacy Policy for Mr Cup Cornetto by AZUMBO (GDPR-ready).',
+    sections: [
+      {
+        id: 'introduction',
+        title: 'Introduction & Scope',
+        content: (
+          <p>
+            We respect your privacy. This Policy explains how AZUMBO handles data for Mr Cup
+            Cornetto.
+          </p>
+        )
+      },
+      {
+        id: 'collect',
+        title: 'What We Collect',
+        content: (
+          <p>
+            On the website we do not collect account data or direct personal data. Our hosting
+            provider may log IP address, user-agent, and timestamps.
+          </p>
+        )
+      },
+      {
+        id: 'cookies',
+        title: 'Cookies/Local Storage',
+        content: (
+          <p>
+            We use only essential cookies or local storage; no tracking cookies are used on these
+            pages.
+          </p>
+        )
+      },
+      {
+        id: 'mobile-ads',
+        title: 'Mobile Ads & Third Parties',
+        content: (
+          <p>
+            Mobile versions may show ads via third parties such as ironSource or Unity Ads. Their
+            data handling is governed by their policies.
+          </p>
+        )
+      },
+      {
+        id: 'legal-bases',
+        title: 'Legal Bases',
+        content: (
+          <p>
+            Legal bases under GDPR Article 6 include legitimate interests (security and fraud
+            prevention), compliance with legal obligations, and consent where required for ads in
+            mobile builds.
+          </p>
+        )
+      },
+      {
+        id: 'use',
+        title: 'How We Use Data',
+        content: (
+          <p>
+            We use data for security, performance, aggregated analytics, and to improve the game.
+          </p>
+        )
+      },
+      {
+        id: 'sharing',
+        title: 'Data Sharing',
+        content: (
+          <p>
+            Data may be shared with hosting and infrastructure providers and with ad networks in
+            mobile apps. We do not sell personal data.
+          </p>
+        )
+      },
+      {
+        id: 'transfers',
+        title: 'International Transfers',
+        content: (
+          <p>
+            When data is transferred outside the EU/EEA, we apply safeguards in line with GDPR,
+            including Standard Contractual Clauses where applicable.
+          </p>
+        )
+      },
+      {
+        id: 'retention',
+        title: 'Data Retention',
+        content: (
+          <p>
+            Data is kept to a minimum and only for as long as necessary for the purposes described.
+          </p>
+        )
+      },
+      {
+        id: 'rights',
+        title: 'Your Rights',
+        content: (
+          <>
+            <p>You have the following rights under GDPR:</p>
+            <ul className="list-disc pl-5">
+              <li>access;</li>
+              <li>rectification;</li>
+              <li>erasure;</li>
+              <li>restriction;</li>
+              <li>portability;</li>
+              <li>objection.</li>
+            </ul>
+            <p>
+              To exercise these rights, contact us at{' '}
+              <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+            </p>
+          </>
+        )
+      },
+      {
+        id: 'children',
+        title: 'Children',
+        content: (
+          <p>
+            The game targets a general audience and we do not knowingly collect personal data from
+            children. Parents can contact us regarding concerns.
+          </p>
+        )
+      },
+      {
+        id: 'links',
+        title: 'Links to Third Parties & Social Sharing',
+        content: (
+          <p>
+            External sites have their own policies. We are not responsible for their content or
+            practices.
+          </p>
+        )
+      },
+      {
+        id: 'changes',
+        title: 'Changes to this Policy',
+        content: (
+          <p>
+            We may update this Policy and will post changes here.
+          </p>
+        )
+      },
+      {
+        id: 'contact',
+        title: 'Contact',
+        content: (
+          <p>
+            For privacy inquiries, email{' '}
+            <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+          </p>
+        )
+      }
+    ],
+    lastUpdated: 'Last Updated: August 14, 2025'
+  },
+  it: {
+    heading: 'Informativa sulla Privacy',
+    metaTitle: 'Informativa sulla Privacy — AZUMBO | Mr Cup Cornetto',
+    metaDescription: 'Informativa sulla privacy per Mr Cup Cornetto di AZUMBO (conforme GDPR).',
+    sections: [
+      {
+        id: 'introduction',
+        title: 'Introduzione e Ambito',
+        content: (
+          <p>
+            Rispettiamo la tua privacy. Questa Informativa spiega come AZUMBO gestisce i dati per Mr
+            Cup Cornetto.
+          </p>
+        )
+      },
+      {
+        id: 'collect',
+        title: 'Cosa Raccogliamo',
+        content: (
+          <p>
+            Sul sito non raccogliamo dati di account né dati personali diretti. Il nostro provider di
+            hosting può registrare IP, user-agent e timestamp.
+          </p>
+        )
+      },
+      {
+        id: 'cookies',
+        title: 'Cookie/Archiviazione Locale',
+        content: (
+          <p>
+            Utilizziamo solo cookie o archiviazione locale essenziali; nessun cookie di tracciamento è
+            presente su queste pagine.
+          </p>
+        )
+      },
+      {
+        id: 'mobile-ads',
+        title: 'Annunci Mobili e Terze Parti',
+        content: (
+          <p>
+            Le versioni mobili possono mostrare annunci tramite terze parti come ironSource o Unity
+            Ads. Il trattamento dei dati è regolato dalle loro politiche.
+          </p>
+        )
+      },
+      {
+        id: 'legal-bases',
+        title: 'Basi Giuridiche',
+        content: (
+          <p>
+            Le basi giuridiche ai sensi dell'articolo 6 GDPR includono interessi legittimi (sicurezza
+            e prevenzione frodi), obblighi legali e consenso quando richiesto per gli annunci nelle
+            build mobili.
+          </p>
+        )
+      },
+      {
+        id: 'use',
+        title: 'Come Usiamo i Dati',
+        content: (
+          <p>
+            Usiamo i dati per sicurezza, prestazioni, analisi aggregate e per migliorare il gioco.
+          </p>
+        )
+      },
+      {
+        id: 'sharing',
+        title: 'Condivisione dei Dati',
+        content: (
+          <p>
+            I dati possono essere condivisi con provider di hosting e infrastruttura e con reti
+            pubblicitarie nelle app mobili. Non vendiamo dati personali.
+          </p>
+        )
+      },
+      {
+        id: 'transfers',
+        title: 'Trasferimenti Internazionali',
+        content: (
+          <p>
+            Quando i dati vengono trasferiti fuori dall'UE/SEE, applichiamo garanzie conformi al GDPR,
+            incluse le Clausole Contrattuali Standard quando applicabili.
+          </p>
+        )
+      },
+      {
+        id: 'retention',
+        title: 'Conservazione dei Dati',
+        content: (
+          <p>
+            I dati sono mantenuti al minimo e solo per il tempo necessario agli scopi descritti.
+          </p>
+        )
+      },
+      {
+        id: 'rights',
+        title: 'I Tuoi Diritti',
+        content: (
+          <>
+            <p>Hai i seguenti diritti ai sensi del GDPR:</p>
+            <ul className="list-disc pl-5">
+              <li>accesso;</li>
+              <li>rettifica;</li>
+              <li>cancellazione;</li>
+              <li>limitazione;</li>
+              <li>portabilità;</li>
+              <li>opposizione.</li>
+            </ul>
+            <p>
+              Per esercitare tali diritti, scrivici a{' '}
+              <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+            </p>
+          </>
+        )
+      },
+      {
+        id: 'children',
+        title: 'Bambini',
+        content: (
+          <p>
+            Il gioco è destinato a un pubblico generico e non raccogliamo consapevolmente dati
+            personali dei minori. I genitori possono contattarci per eventuali dubbi.
+          </p>
+        )
+      },
+      {
+        id: 'links',
+        title: 'Link a Terzi e Condivisione Sociale',
+        content: (
+          <p>
+            I siti esterni hanno le proprie politiche. Non siamo responsabili dei loro contenuti o
+            pratiche.
+          </p>
+        )
+      },
+      {
+        id: 'changes',
+        title: 'Modifiche a questa Informativa',
+        content: (
+          <p>
+            Possiamo aggiornare questa Informativa e pubblicheremo qui le modifiche.
+          </p>
+        )
+      },
+      {
+        id: 'contact',
+        title: 'Contatti',
+        content: (
+          <p>
+            Per richieste sulla privacy, invia un'email a{' '}
+            <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+          </p>
+        )
+      }
+    ],
+    lastUpdated: 'Ultimo aggiornamento: 14 agosto 2025'
+  },
+  ru: {
+    heading: 'Политика конфиденциальности',
+    metaTitle: 'Политика конфиденциальности — AZUMBO | Mr Cup Cornetto',
+    metaDescription: 'Политика конфиденциальности Mr Cup Cornetto от AZUMBO (GDPR).',
+    sections: [
+      {
+        id: 'introduction',
+        title: 'Введение и сфера действия',
+        content: (
+          <p>
+            Мы уважаем вашу конфиденциальность. Эта Политика объясняет, как AZUMBO обрабатывает данные
+            для Mr Cup Cornetto.
+          </p>
+        )
+      },
+      {
+        id: 'collect',
+        title: 'Что мы собираем',
+        content: (
+          <p>
+            На веб‑сайте мы не собираем данные аккаунта или прямые персональные данные. Провайдер
+            хостинга может вести журналы IP‑адресов, user-agent и отметок времени.
+          </p>
+        )
+      },
+      {
+        id: 'cookies',
+        title: 'Cookies/Локальное хранилище',
+        content: (
+          <p>
+            Мы используем только необходимые cookie или локальное хранилище; на этих страницах нет
+            отслеживающих cookie.
+          </p>
+        )
+      },
+      {
+        id: 'mobile-ads',
+        title: 'Мобильная реклама и сторонние сервисы',
+        content: (
+          <p>
+            Мобильные версии могут показывать рекламу через сторонние сети, такие как ironSource или
+            Unity Ads. Обработка данных регулируется их политиками.
+          </p>
+        )
+      },
+      {
+        id: 'legal-bases',
+        title: 'Правовые основания',
+        content: (
+          <p>
+            Правовые основания в соответствии со ст. 6 GDPR включают законные интересы (безопасность и
+            предотвращение мошенничества), выполнение правовых обязательств и согласие, когда оно
+            требуется для рекламы в мобильных сборках.
+          </p>
+        )
+      },
+      {
+        id: 'use',
+        title: 'Как мы используем данные',
+        content: (
+          <p>
+            Мы используем данные для безопасности, производительности, агрегированной аналитики и
+            улучшения игры.
+          </p>
+        )
+      },
+      {
+        id: 'sharing',
+        title: 'Передача данных',
+        content: (
+          <p>
+            Данные могут передаваться провайдерам хостинга и инфраструктуры, а также рекламным сетям в
+            мобильных приложениях. Мы не продаём персональные данные.
+          </p>
+        )
+      },
+      {
+        id: 'transfers',
+        title: 'Международные передачи',
+        content: (
+          <p>
+            При передаче данных за пределы ЕС/ЕЭЗ мы применяем меры защиты в соответствии с GDPR,
+            включая стандартные договорные положения, когда это применимо.
+          </p>
+        )
+      },
+      {
+        id: 'retention',
+        title: 'Хранение данных',
+        content: (
+          <p>
+            Данные хранятся минимально и только столько, сколько необходимо для описанных целей.
+          </p>
+        )
+      },
+      {
+        id: 'rights',
+        title: 'Ваши права',
+        content: (
+          <>
+            <p>Согласно GDPR вы имеете права:</p>
+            <ul className="list-disc pl-5">
+              <li>на доступ;</li>
+              <li>на исправление;</li>
+              <li>на удаление;</li>
+              <li>на ограничение обработки;</li>
+              <li>на переносимость;</li>
+              <li>на возражение.</li>
+            </ul>
+            <p>
+              Для реализации прав напишите нам на{' '}
+              <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+            </p>
+          </>
+        )
+      },
+      {
+        id: 'children',
+        title: 'Дети',
+        content: (
+          <p>
+            Игра рассчитана на широкую аудиторию; мы сознательно не собираем персональные данные
+            детей. Родители могут связаться с нами при наличии вопросов.
+          </p>
+        )
+      },
+      {
+        id: 'links',
+        title: 'Ссылки на сторонние ресурсы и социальный обмен',
+        content: (
+          <p>
+            Внешние сайты имеют собственные политики. Мы не несём ответственности за их содержимое или
+            практики.
+          </p>
+        )
+      },
+      {
+        id: 'changes',
+        title: 'Изменения этой Политики',
+        content: (
+          <p>
+            Мы можем обновлять эту Политику и опубликуем изменения здесь.
+          </p>
+        )
+      },
+      {
+        id: 'contact',
+        title: 'Контакты',
+        content: (
+          <p>
+            По вопросам конфиденциальности пишите на{' '}
+            <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+          </p>
+        )
+      }
+    ],
+    lastUpdated: 'Дата обновления: 14 августа 2025'
+  }
+};
+
+export default function PrivacyPage() {
+  const [lang, setLang] = useState<Language>('en');
+  const current = content[lang];
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: current.metaTitle,
+    inLanguage: lang,
+    description: current.metaDescription,
+    url: 'https://azumbo.com/cornettoclicker/privacy'
+  };
+
+  return (
+    <article lang={lang} className="container mx-auto max-w-3xl px-4 py-8">
+      <div className="bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 shadow-sm rounded-md p-6 leading-relaxed space-y-6">
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="text-2xl font-bold">AZUMBO</div>
+            <p className="text-sm">Mr Cup Cornetto — Legal</p>
+          </div>
+          <LanguageSwitch lang={lang} setLang={setLang} />
+        </div>
+        <h1 className="text-3xl font-bold text-center">{current.heading}</h1>
+        <nav className="text-sm">
+          <ul className="flex flex-wrap gap-2">
+            {current.sections.map((s) => (
+              <li key={s.id}>
+                <a href={`#${s.id}`} className="underline">
+                  {s.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        {current.sections.map((s) => (
+          <section id={s.id} key={s.id} className="space-y-2">
+            <h2 className="text-xl font-semibold">{s.title}</h2>
+            {s.content}
+          </section>
+        ))}
+        <p className="text-sm text-gray-500 dark:text-zinc-400">{current.lastUpdated}</p>
+        <div className="text-sm">
+          <a href="/cornettoclicker/privacy" className="underline">Privacy Policy</a> ↔{' '}
+          <a href="/cornettoclicker/terms" className="underline">Terms of Service</a>
+        </div>
+        <footer className="border-t border-gray-200 dark:border-zinc-700 pt-4 text-center text-sm">
+          © 2025 AZUMBO —{' '}
+          <a href="mailto:azumbogames@gmail.com" className="underline">
+            azumbogames@gmail.com
+          </a>
+        </footer>
+      </div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </article>
+  );
+}
+

--- a/app/cornettoclicker/terms/metadata.ts
+++ b/app/cornettoclicker/terms/metadata.ts
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '[EN/IT/RU] Terms of Service — AZUMBO | Mr Cup Cornetto',
+  description: 'Official Terms of Service for Mr Cup Cornetto by AZUMBO.',
+  alternates: {
+    canonical: 'https://azumbo.com/cornettoclicker/terms'
+  },
+  openGraph: {
+    title: '[EN/IT/RU] Terms of Service — AZUMBO | Mr Cup Cornetto',
+    description: 'Official Terms of Service for Mr Cup Cornetto by AZUMBO.',
+    url: 'https://azumbo.com/cornettoclicker/terms'
+  },
+  twitter: {
+    card: 'summary',
+    title: '[EN/IT/RU] Terms of Service — AZUMBO | Mr Cup Cornetto',
+    description: 'Official Terms of Service for Mr Cup Cornetto by AZUMBO.'
+  },
+  robots: {
+    index: true,
+    follow: true
+  }
+};
+
+export default metadata;

--- a/app/cornettoclicker/terms/page.tsx
+++ b/app/cornettoclicker/terms/page.tsx
@@ -1,0 +1,474 @@
+'use client';
+
+import { useState } from 'react';
+import LanguageSwitch, { Language } from '../../../components/LanguageSwitch';
+import type { ReactNode } from 'react';
+
+interface Section {
+  id: string;
+  title: string;
+  content: ReactNode;
+}
+
+interface PageContent {
+  heading: string;
+  metaTitle: string;
+  metaDescription: string;
+  sections: Section[];
+  lastUpdated: string;
+}
+
+const content: Record<Language, PageContent> = {
+  en: {
+    heading: 'Terms of Service',
+    metaTitle: 'Terms of Service — AZUMBO | Mr Cup Cornetto',
+    metaDescription: 'Official Terms of Service for Mr Cup Cornetto by AZUMBO.',
+    sections: [
+      {
+        id: 'introduction',
+        title: 'Introduction',
+        content: (
+          <p>
+            These Terms of Service (“Terms”) govern your use of Mr Cup Cornetto by AZUMBO. By
+            accessing or using the game or related services, you agree to these Terms.
+          </p>
+        )
+      },
+      {
+        id: 'eligibility',
+        title: 'Eligibility & Platform',
+        content: (
+          <p>
+            You must be legally permitted to use the service in your jurisdiction. The game is
+            available on the web and may be distributed on mobile platforms. Some features may
+            vary by platform.
+          </p>
+        )
+      },
+      {
+        id: 'gameplay',
+        title: 'Gameplay & Virtual Items',
+        content: (
+          <p>
+            Mr Cup Cornetto offers purely virtual items and gameplay benefits without real-world
+            value. The web version has no purchases or real-money transactions. Mobile versions
+            may display advertisements.
+          </p>
+        )
+      },
+      {
+        id: 'ads',
+        title: 'Ads & Third Parties',
+        content: (
+          <p>
+            Mobile builds may integrate ad networks such as ironSource or Unity Ads. Ads or
+            external links may take you away from the game. AZUMBO is not responsible for
+            third-party content or policies.
+          </p>
+        )
+      },
+      {
+        id: 'conduct',
+        title: 'User Conduct',
+        content: (
+          <>
+            <p>You agree not to:</p>
+            <ul className="list-disc pl-5">
+              <li>cheat, exploit bugs, or interfere with gameplay;</li>
+              <li>upload or share illegal or offensive content;</li>
+              <li>violate any applicable laws or regulations.</li>
+            </ul>
+          </>
+        )
+      },
+      {
+        id: 'ip',
+        title: 'IP & License',
+        content: (
+          <p>
+            All intellectual property in Mr Cup Cornetto remains with AZUMBO. We grant you a
+            limited, revocable, non-transferable license to use the game for personal,
+            non-commercial purposes.
+          </p>
+        )
+      },
+      {
+        id: 'disclaimer',
+        title: 'Disclaimers & Limitation of Liability',
+        content: (
+          <>
+            <p>The game is provided “AS IS” without warranties. To the extent permitted by law:</p>
+            <ul className="list-disc pl-5">
+              <li>AZUMBO disclaims all implied warranties; and</li>
+              <li>AZUMBO is not liable for indirect, incidental, or consequential damages.</li>
+            </ul>
+          </>
+        )
+      },
+      {
+        id: 'termination',
+        title: 'Termination',
+        content: (
+          <p>
+            We may suspend or terminate your access to the game at any time for any reason,
+            including violation of these Terms.
+          </p>
+        )
+      },
+      {
+        id: 'changes',
+        title: 'Changes to the Terms',
+        content: (
+          <p>
+            We may modify these Terms from time to time. Material changes will be posted, and
+            continued use after changes means acceptance.
+          </p>
+        )
+      },
+      {
+        id: 'law',
+        title: 'Governing Law & Dispute Resolution',
+        content: (
+          <p>
+            These Terms are governed by the laws of Italy and applicable EU regulations. Mandatory
+            consumer rights remain unaffected. Disputes will be resolved in the courts of Italy
+            unless local law requires otherwise.
+          </p>
+        )
+      },
+      {
+        id: 'contact',
+        title: 'Contact',
+        content: (
+          <p>
+            For questions, email <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+          </p>
+        )
+      }
+    ],
+    lastUpdated: 'Last Updated: August 14, 2025'
+  },
+  it: {
+    heading: 'Condizioni di Servizio',
+    metaTitle: 'Condizioni di Servizio — AZUMBO | Mr Cup Cornetto',
+    metaDescription: 'Condizioni di servizio ufficiali di Mr Cup Cornetto di AZUMBO.',
+    sections: [
+      {
+        id: 'introduction',
+        title: 'Introduzione',
+        content: (
+          <p>
+            Queste Condizioni di Servizio (“Condizioni”) regolano l'uso di Mr Cup Cornetto da parte
+            di AZUMBO. Accedendo o utilizzando il gioco accetti tali Condizioni.
+          </p>
+        )
+      },
+      {
+        id: 'eligibility',
+        title: 'Idoneità e Piattaforme',
+        content: (
+          <p>
+            Devi essere legalmente autorizzato a usare il servizio nel tuo territorio. Il gioco è
+            disponibile sul web e può essere distribuito su piattaforme mobili. Alcune funzioni
+            possono variare a seconda della piattaforma.
+          </p>
+        )
+      },
+      {
+        id: 'gameplay',
+        title: 'Gameplay e Oggetti Virtuali',
+        content: (
+          <p>
+            Mr Cup Cornetto offre esclusivamente oggetti virtuali e vantaggi di gioco senza valore
+            reale. Nella versione web non sono previste transazioni o acquisti con denaro reale. Le
+            versioni mobili possono mostrare pubblicità.
+          </p>
+        )
+      },
+      {
+        id: 'ads',
+        title: 'Pubblicità e Terze Parti',
+        content: (
+          <p>
+            Le build mobili possono integrare reti pubblicitarie come ironSource o Unity Ads. Gli
+            annunci o i link esterni possono portarti fuori dal gioco. AZUMBO non è responsabile per
+            contenuti o politiche di terzi.
+          </p>
+        )
+      },
+      {
+        id: 'conduct',
+        title: 'Condotta dell’Utente',
+        content: (
+          <>
+            <p>Ti impegni a non:</p>
+            <ul className="list-disc pl-5">
+              <li>barare, sfruttare bug o interferire con il gameplay;</li>
+              <li>caricare o condividere contenuti illegali o offensivi;</li>
+              <li>violare leggi o regolamenti applicabili.</li>
+            </ul>
+          </>
+        )
+      },
+      {
+        id: 'ip',
+        title: 'Proprietà Intellettuale e Licenza',
+        content: (
+          <p>
+            Tutta la proprietà intellettuale di Mr Cup Cornetto rimane di AZUMBO. Ti concediamo una
+            licenza limitata, revocabile e non trasferibile per usare il gioco a fini personali e non
+            commerciali.
+          </p>
+        )
+      },
+      {
+        id: 'disclaimer',
+        title: 'Esclusioni di Garanzia e Limitazioni di Responsabilità',
+        content: (
+          <>
+            <p>Il gioco è fornito “COSÌ COM'È” senza garanzie. Nella misura consentita dalla legge:</p>
+            <ul className="list-disc pl-5">
+              <li>AZUMBO declina tutte le garanzie implicite; e</li>
+              <li>AZUMBO non è responsabile per danni indiretti, incidentali o consequenziali.</li>
+            </ul>
+          </>
+        )
+      },
+      {
+        id: 'termination',
+        title: 'Risoluzione',
+        content: (
+          <p>
+            Possiamo sospendere o terminare il tuo accesso al gioco in qualsiasi momento per qualsiasi
+            motivo, incluso il mancato rispetto di queste Condizioni.
+          </p>
+        )
+      },
+      {
+        id: 'changes',
+        title: 'Modifiche alle Condizioni',
+        content: (
+          <p>
+            Possiamo modificare queste Condizioni periodicamente. Le modifiche rilevanti saranno
+            pubblicate e l'uso continuato dopo le modifiche implica accettazione.
+          </p>
+        )
+      },
+      {
+        id: 'law',
+        title: 'Legge Applicabile e Controversie',
+        content: (
+          <p>
+            Le presenti Condizioni sono regolate dalla legge italiana e dalle normative UE
+            applicabili. I diritti dei consumatori previsti per legge restano invariati. Le
+            controversie saranno risolte presso i tribunali italiani salvo diversa disposizione di
+            legge locale.
+          </p>
+        )
+      },
+      {
+        id: 'contact',
+        title: 'Contatti',
+        content: (
+          <p>
+            Per domande, invia un'email a <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+          </p>
+        )
+      }
+    ],
+    lastUpdated: 'Ultimo aggiornamento: 14 agosto 2025'
+  },
+  ru: {
+    heading: 'Условия использования',
+    metaTitle: 'Условия использования — AZUMBO | Mr Cup Cornetto',
+    metaDescription: 'Официальные Условия использования Mr Cup Cornetto от AZUMBO.',
+    sections: [
+      {
+        id: 'introduction',
+        title: 'Введение',
+        content: (
+          <p>
+            Настоящие Условия использования («Условия») регулируют ваше использование игры Mr Cup
+            Cornetto компании AZUMBO. Получая доступ к игре или используя её, вы соглашаетесь с этими
+            Условиями.
+          </p>
+        )
+      },
+      {
+        id: 'eligibility',
+        title: 'Допуск и платформы',
+        content: (
+          <p>
+            Вы должны иметь право пользоваться сервисом в своей юрисдикции. Игра доступна в вебе и
+            может распространяться на мобильных платформах. Возможности могут различаться в
+            зависимости от платформы.
+          </p>
+        )
+      },
+      {
+        id: 'gameplay',
+        title: 'Геймплей и виртуальные предметы',
+        content: (
+          <p>
+            Mr Cup Cornetto предлагает исключительно виртуальные предметы и игровые преимущества, не
+            имеющие реальной ценности. На веб‑странице нет покупок или операций с реальными деньгами.
+            Мобильные версии могут показывать рекламу.
+          </p>
+        )
+      },
+      {
+        id: 'ads',
+        title: 'Реклама и сторонние сервисы',
+        content: (
+          <p>
+            В мобильных сборках могут использоваться рекламные сети, такие как ironSource или Unity
+            Ads. Объявления или внешние ссылки могут перенаправлять вас с сайта. AZUMBO не несёт
+            ответственности за сторонний контент и политики.
+          </p>
+        )
+      },
+      {
+        id: 'conduct',
+        title: 'Поведение пользователя',
+        content: (
+          <>
+            <p>Вы соглашаетесь не:</p>
+            <ul className="list-disc pl-5">
+              <li>читерить, использовать ошибки или мешать игровому процессу;</li>
+              <li>загружать или распространять незаконный либо оскорбительный контент;</li>
+              <li>нарушать любые применимые законы и правила.</li>
+            </ul>
+          </>
+        )
+      },
+      {
+        id: 'ip',
+        title: 'Права ИС и лицензия',
+        content: (
+          <p>
+            Все права на интеллектуальную собственность Mr Cup Cornetto принадлежат AZUMBO. Вам
+            предоставляется ограниченная, отзывная, непередаваемая лицензия на использование игры в
+            личных некоммерческих целях.
+          </p>
+        )
+      },
+      {
+        id: 'disclaimer',
+        title: 'Отказ от гарантий и ограничение ответственности',
+        content: (
+          <>
+            <p>Игра предоставляется «КАК ЕСТЬ» без каких-либо гарантий. В пределах, допускаемых
+              законом:</p>
+            <ul className="list-disc pl-5">
+              <li>AZUMBO отказывается от всех подразумеваемых гарантий; и</li>
+              <li>AZUMBO не несёт ответственности за косвенные, случайные или последующие убытки.</li>
+            </ul>
+          </>
+        )
+      },
+      {
+        id: 'termination',
+        title: 'Прекращение действия',
+        content: (
+          <p>
+            Мы можем приостановить или прекратить ваш доступ к игре в любое время и по любой причине,
+            включая нарушение настоящих Условий.
+          </p>
+        )
+      },
+      {
+        id: 'changes',
+        title: 'Изменения Условий',
+        content: (
+          <p>
+            Мы можем периодически обновлять эти Условия. Существенные изменения будут опубликованы, и
+            продолжение использования после изменений означает ваше согласие.
+          </p>
+        )
+      },
+      {
+        id: 'law',
+        title: 'Применимое право и споры',
+        content: (
+          <p>
+            Настоящие Условия регулируются законами Италии и применимым законодательством ЕС.
+            Обязательные права потребителей сохраняются. Споры подлежат рассмотрению в судах Италии,
+            если иное не предусмотрено обязательным законодательством.
+          </p>
+        )
+      },
+      {
+        id: 'contact',
+        title: 'Контакты',
+        content: (
+          <p>
+            По вопросам пишите на <a className="underline" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.
+          </p>
+        )
+      }
+    ],
+    lastUpdated: 'Дата обновления: 14 августа 2025'
+  }
+};
+
+export default function TermsPage() {
+  const [lang, setLang] = useState<Language>('en');
+  const current = content[lang];
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: current.metaTitle,
+    inLanguage: lang,
+    description: current.metaDescription,
+    url: 'https://azumbo.com/cornettoclicker/terms'
+  };
+
+  return (
+    <article lang={lang} className="container mx-auto max-w-3xl px-4 py-8">
+      <div className="bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 shadow-sm rounded-md p-6 leading-relaxed space-y-6">
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="text-2xl font-bold">AZUMBO</div>
+            <p className="text-sm">Mr Cup Cornetto — Legal</p>
+          </div>
+          <LanguageSwitch lang={lang} setLang={setLang} />
+        </div>
+        <h1 className="text-3xl font-bold text-center">{current.heading}</h1>
+        <nav className="text-sm">
+          <ul className="flex flex-wrap gap-2">
+            {current.sections.map((s) => (
+              <li key={s.id}>
+                <a href={`#${s.id}`} className="underline">
+                  {s.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        {current.sections.map((s) => (
+          <section id={s.id} key={s.id} className="space-y-2">
+            <h2 className="text-xl font-semibold">{s.title}</h2>
+            {s.content}
+          </section>
+        ))}
+        <p className="text-sm text-gray-500 dark:text-zinc-400">{current.lastUpdated}</p>
+        <div className="text-sm">
+          <a href="/cornettoclicker/privacy" className="underline">Privacy Policy</a> ↔{' '}
+          <a href="/cornettoclicker/terms" className="underline">Terms of Service</a>
+        </div>
+        <footer className="border-t border-gray-200 dark:border-zinc-700 pt-4 text-center text-sm">
+          © 2025 AZUMBO —{' '}
+          <a href="mailto:azumbogames@gmail.com" className="underline">
+            azumbogames@gmail.com
+          </a>
+        </footer>
+      </div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </article>
+  );
+}
+

--- a/components/LanguageSwitch.tsx
+++ b/components/LanguageSwitch.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import type { Dispatch, SetStateAction } from 'react';
+
+export type Language = 'en' | 'it' | 'ru';
+
+export default function LanguageSwitch({ lang, setLang }: { lang: Language; setLang: Dispatch<SetStateAction<Language>>; }) {
+  const languages: Language[] = ['en', 'it', 'ru'];
+
+  return (
+    <div className="sticky top-0 flex gap-2 bg-white/80 dark:bg-zinc-900/80 backdrop-blur px-2 py-1 rounded-md shadow-sm">
+      {languages.map((l) => (
+        <button
+          key={l}
+          onClick={() => setLang(l)}
+          className={`text-sm uppercase ${lang === l ? 'font-bold underline' : ''}`}
+        >
+          {l}
+        </button>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add English, Italian and Russian Terms of Service for CornettoClicker
- add corresponding Privacy Policy with GDPR-ready notes
- implement sticky client-side LanguageSwitch shared by both pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e13a11700832c99c9b136f6f57335