### PR TITLE
feat(frogger): split desktop/mobile controls; dpad -20%; iOS 100dvh & safe-area; swipe support

### DIFF
--- a/public/frogger/index.html
+++ b/public/frogger/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <title>Frogger</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body id="game-root">
+  <canvas id="game-canvas"></canvas>
+  <div id="dpad" class="dpad hidden" aria-hidden="true">
+    <button id="btn-up" class="dpad-btn" aria-label="Up">▲</button>
+    <div class="dpad-row">
+      <button id="btn-left" class="dpad-btn" aria-label="Left">◀</button>
+      <button id="btn-right" class="dpad-btn" aria-label="Right">▶</button>
+    </div>
+    <button id="btn-down" class="dpad-btn" aria-label="Down">▼</button>
+  </div>
+
+  <script src="./js/game.js"></script>
+  <script src="./js/FroggerDesktopControls.js"></script>
+  <script src="./js/FroggerMobileControls.js"></script>
+  <script>
+    (function initInput(){
+      const isMobile = window.matchMedia('(pointer: coarse)').matches
+                    || ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
+
+      const root = document.getElementById('game-root') || document.body;
+      const dpad = document.getElementById('dpad');
+
+      let input;
+      if (isMobile) {
+        dpad.classList.remove('hidden');
+        input = new FroggerMobileControls({
+          root,
+          up:   document.getElementById('btn-up'),
+          down: document.getElementById('btn-down'),
+          left: document.getElementById('btn-left'),
+          right:document.getElementById('btn-right'),
+          swipe: true
+        });
+      } else {
+        dpad.classList.add('hidden');
+        input = new FroggerDesktopControls();
+      }
+
+      window.__frogInput = input;
+    })();
+  </script>
+</body>
+</html>

--- a/public/frogger/js/FroggerDesktopControls.js
+++ b/public/frogger/js/FroggerDesktopControls.js
@@ -1,0 +1,17 @@
+(function(){
+  class FroggerDesktopControls {
+    constructor(){
+      this._queue = [];
+      window.addEventListener('keydown', (e) => {
+        if (e.repeat) return;
+        const k = e.key;
+        if (k === 'ArrowUp'   || k === 'w' || k === 'W') this._queue.push('up');
+        if (k === 'ArrowDown' || k === 's' || k === 'S') this._queue.push('down');
+        if (k === 'ArrowLeft' || k === 'a' || k === 'A') this._queue.push('left');
+        if (k === 'ArrowRight'|| k === 'd' || k === 'D') this._queue.push('right');
+      }, { passive: true });
+    }
+    consume(){ return this._queue.shift() || null; }
+  }
+  window.FroggerDesktopControls = FroggerDesktopControls;
+})();

--- a/public/frogger/js/FroggerMobileControls.js
+++ b/public/frogger/js/FroggerMobileControls.js
@@ -1,0 +1,38 @@
+(function(){
+  class FroggerMobileControls {
+    constructor({ root, up, down, left, right, swipe = true }){
+      this._queue = [];
+      this._root = root || document.body;
+
+      const onTap = (cmd) => (ev) => { ev.preventDefault(); this._queue.push(cmd); };
+      [['up',up], ['down',down], ['left',left], ['right',right]].forEach(([cmd, btn])=>{
+        ['pointerdown','touchstart','mousedown'].forEach(t =>
+          btn.addEventListener(t, onTap(cmd), { passive: false })
+        );
+      });
+
+      if (swipe) {
+        let sx=0, sy=0, active=false;
+        const start = (e)=>{ active=true; sx=e.clientX||e.touches?.[0]?.clientX||0; sy=e.clientY||e.touches?.[0]?.clientY||0; };
+        const end   = (e)=>{
+          if(!active) return; active=false;
+          const ex=e.clientX||e.changedTouches?.[0]?.clientX||0;
+          const ey=e.clientY||e.changedTouches?.[0]?.clientY||0;
+          const dx=ex-sx, dy=ey-sy;
+          const th = Math.max(24, Math.min(56, Math.floor(window.innerWidth*0.06)));
+          if (Math.abs(dx) < th && Math.abs(dy) < th) return;
+          if (Math.abs(dx) > Math.abs(dy)) this._queue.push(dx>0?'right':'left');
+          else this._queue.push(dy>0?'down':'up');
+        };
+        this._root.addEventListener('pointerdown', start, { passive: true });
+        this._root.addEventListener('pointerup',   end,   { passive: true });
+        this._root.addEventListener('touchstart',  start, { passive: true });
+        this._root.addEventListener('touchend',    end,   { passive: true });
+
+        this._root.addEventListener('touchmove', (e)=> e.preventDefault(), { passive: false });
+      }
+    }
+    consume(){ return this._queue.shift() || null; }
+  }
+  window.FroggerMobileControls = FroggerMobileControls;
+})();

--- a/public/frogger/js/game.js
+++ b/public/frogger/js/game.js
@@ -1,0 +1,151 @@
+(function(){
+  function init(){
+    const canvas = document.getElementById('game-canvas');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const cols = 10;
+    const rows = 8;
+    const maxWidth = Math.min(window.innerWidth * 0.9, 40 * cols);
+    const tile = Math.floor(maxWidth / cols);
+    canvas.width = cols * tile;
+    canvas.height = rows * tile;
+    canvas.style.width = `${canvas.width}px`;
+    canvas.style.height = `${canvas.height}px`;
+
+    const frog = { x: 4, y: rows - 1 };
+    const cars = [
+      { x: 0, y: rows - 2, speed: 2 },
+      { x: 200, y: rows - 3, speed: -2 },
+    ];
+    const logs = [
+      { x: 0, y: 3, speed: 1.5 },
+      { x: 200, y: 2, speed: -1.5 },
+    ];
+    const houses = [1, 4, 7];
+    let homes = [false, false, false];
+    let status = 'play';
+
+    const reset = () => {
+      frog.x = 4;
+      frog.y = rows - 1;
+    };
+
+    const update = (dt) => {
+      if (status !== 'play') return;
+      const cmd = (window.__frogInput && window.__frogInput.consume) ? window.__frogInput.consume() : null;
+      if (cmd) {
+        switch(cmd){
+          case 'left': if (frog.x > 0) frog.x -= 1; break;
+          case 'right': if (frog.x < cols - 1) frog.x += 1; break;
+          case 'up': if (frog.y > 0) frog.y -= 1; break;
+          case 'down': if (frog.y < rows - 1) frog.y += 1; break;
+        }
+      }
+
+      cars.forEach((c) => {
+        c.x += c.speed * dt * tile;
+        if (c.speed > 0 && c.x > cols * tile) c.x = -tile;
+        if (c.speed < 0 && c.x < -tile) c.x = cols * tile;
+      });
+      logs.forEach((l) => {
+        l.x += l.speed * dt * tile;
+        if (l.speed > 0 && l.x > cols * tile) l.x = -tile * 2;
+        if (l.speed < 0 && l.x < -tile * 2) l.x = cols * tile;
+      });
+
+      cars.forEach((c) => {
+        if (
+          frog.y === c.y &&
+          frog.x * tile < c.x + tile &&
+          frog.x * tile + tile > c.x
+        ) {
+          reset();
+        }
+      });
+
+      if (frog.y === 3 || frog.y === 2) {
+        let onLog = false;
+        logs.forEach((l) => {
+          if (
+            frog.y === l.y &&
+            frog.x * tile < l.x + tile * 2 &&
+            frog.x * tile + tile > l.x
+          ) {
+            onLog = true;
+            frog.x += l.speed * dt;
+          }
+        });
+        if (!onLog) {
+          reset();
+        }
+      }
+
+      if (frog.y === 0) {
+        let reached = -1;
+        houses.forEach((h, i) => {
+          if (!homes[i] && Math.abs(frog.x - h) < 1) reached = i;
+        });
+        if (reached >= 0) {
+          homes[reached] = true;
+          reset();
+          if (homes.every((v) => v)) status = 'win';
+        } else {
+          reset();
+        }
+      }
+
+      frog.x = Math.max(0, Math.min(cols - 1, frog.x));
+    };
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      ctx.fillStyle = 'green';
+      ctx.fillRect(0, 0, canvas.width, tile);
+      ctx.fillRect(0, (rows - 1) * tile, canvas.width, tile);
+
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(0, 2 * tile, canvas.width, tile * 2);
+
+      ctx.fillStyle = 'grey';
+      ctx.fillRect(0, 4 * tile, canvas.width, tile);
+
+      ctx.fillStyle = 'brown';
+      cars.forEach((c) => ctx.fillRect(c.x, c.y * tile, tile, tile));
+      logs.forEach((l) => ctx.fillRect(l.x, l.y * tile, tile * 2, tile));
+
+      ctx.fillStyle = 'purple';
+      houses.forEach((h) => ctx.fillRect(h * tile, 0, tile, tile));
+      ctx.fillStyle = 'lightgreen';
+      homes.forEach((taken, i) => {
+        if (taken) ctx.fillRect(houses[i] * tile, 0, tile, tile);
+      });
+
+      ctx.fillStyle = 'lime';
+      ctx.fillRect(frog.x * tile, frog.y * tile, tile, tile);
+
+      if (status === 'win') {
+        ctx.fillStyle = 'rgba(0,0,0,0.5)';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = 'white';
+        ctx.font = '20px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('You Win!', canvas.width / 2, canvas.height / 2);
+      }
+    };
+
+    let last = 0;
+    const loop = (ts) => {
+      const dt = (ts - last) / 1000;
+      last = ts;
+      update(dt);
+      draw();
+      requestAnimationFrame(loop);
+    };
+    requestAnimationFrame(loop);
+  }
+
+  window.addEventListener('load', init);
+})();

--- a/public/frogger/styles.css
+++ b/public/frogger/styles.css
@@ -1,0 +1,58 @@
+:root {
+  --btn-base: 88px;
+  --btn-size: calc(var(--btn-base) * 0.8);
+}
+
+#game-root {
+  min-height: 100dvh;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+#game-root, #game-canvas {
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.dpad {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: grid;
+  grid-template-rows: auto auto auto;
+  justify-items: center;
+  gap: 10px;
+  padding: 12px calc(env(safe-area-inset-right, 0px) + 12px)
+           calc(env(safe-area-inset-bottom, 0px) + 12px)
+           calc(env(safe-area-inset-left, 0px) + 12px);
+  pointer-events: none;
+  z-index: 10;
+}
+
+.dpad-row {
+  display: flex;
+  gap: 14px;
+}
+
+.dpad-btn {
+  pointer-events: auto;
+  width: var(--btn-size);
+  height: var(--btn-size);
+  border: 0;
+  border-radius: 16px;
+  background: rgba(0,0,0,0.35);
+  color: #fff;
+  font-size: 26px;
+  font-weight: 700;
+  backdrop-filter: blur(6px);
+  touch-action: none;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (pointer: fine) {
+  #dpad { display: none !important; }
+}


### PR DESCRIPTION
## Summary
- add Frogger desktop/mobile control scripts and queue-based input
- render responsive D-pad with -20% sizing and swipe gestures
- apply 100dvh and safe-area paddings for iOS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e4ffea368832c8c9c6c2dce29b656