### PR TITLE
Remove Commander Mola Mola branding

### DIFF
--- a/app/CommanderMolaMola/finish/page.tsx
+++ b/app/CommanderMolaMola/finish/page.tsx
@@ -1,2 +1,0 @@
-import Finish from '../../finish/page';
-export default Finish;

--- a/app/CommanderMolaMola/game/page.tsx
+++ b/app/CommanderMolaMola/game/page.tsx
@@ -1,2 +1,0 @@
-import Game from '../../game/page';
-export default Game;

--- a/app/CommanderMolaMola/page.tsx
+++ b/app/CommanderMolaMola/page.tsx
@@ -1,2 +1,0 @@
-import LangSelect from '../page';
-export default LangSelect;

--- a/app/CommanderMolaMola/register/page.tsx
+++ b/app/CommanderMolaMola/register/page.tsx
@@ -1,2 +1,0 @@
-import Register from '../../register/page';
-export default Register;

--- a/app/CommanderMolaMola/stats/page.tsx
+++ b/app/CommanderMolaMola/stats/page.tsx
@@ -1,2 +1,0 @@
-import Stats from '../../stats/page';
-export default Stats;

--- a/app/finish/page.tsx
+++ b/app/finish/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { localization, gameConfig } from '../../lib/config';
+import { localization } from '../../lib/config';
 
 export default function FinishPage() {
   const [lang, setLang] = useState('en');
@@ -22,13 +22,6 @@ export default function FinishPage() {
     <div className="pixel-container">
       <h1>{t.finishScreen.title}</h1>
       <p>{t.finishScreen.message}</p>
-      <p>{t.finishScreen.action} {gameConfig.adminEmail}</p>
-      <p>{t.finishScreen.social}</p>
-      <a href={gameConfig.socialLinks.youtube}>{gameConfig.socialLinks.youtube}</a>
-      <br />
-      <a href={gameConfig.socialLinks.tiktok}>{gameConfig.socialLinks.tiktok}</a>
-      <p>{t.finishScreen.comment}</p>
-      <img src="/mola-coin.png" alt="Mola Coin" className="pixel-coin" />
       <p>{code}</p>
       <button className="pixel-button" onClick={copy}>{t.finishScreen.copy}</button>
       <div style={{ marginTop: '20px' }}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ const pressStart = Press_Start_2P({
 });
 
 export const metadata = {
-  title: 'Commander Mola Mola Pixel Quest',
+  title: 'Pixel Quest',
   viewport: {
     width: 'device-width',
     initialScale: 1,
@@ -23,7 +23,7 @@ export const metadata = {
   appleWebApp: {
     capable: true,
     statusBarStyle: 'black-translucent',
-    title: 'Commander Mola Mola Pixel Quest'
+    title: 'Pixel Quest'
   }
 };
 
@@ -38,7 +38,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-        <meta name="apple-mobile-web-app-title" content="Commander Mola Mola Pixel Quest" />
+        <meta name="apple-mobile-web-app-title" content="Pixel Quest" />
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
       </head>
       <body className={`${pressStart.className} overscroll-none`}>

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,13 +1,8 @@
 export const gameConfig = {
-  title: 'Commander Mola Mola Pixel Quest',
+  title: 'Pixel Quest',
   languages: ['en', 'it', 'ru'],
   defaultLanguage: 'en',
   apiEndpoint: '/api',
-  adminEmail: 'CommanderMolaMola@gmail.com',
-  socialLinks: {
-    youtube: 'https://www.youtube.com/@CommanderMolaMola',
-    tiktok: 'https://www.tiktok.com/@commandermolamola',
-  },
 };
 
 export const localization = {
@@ -22,10 +17,7 @@ export const localization = {
     },
     finishScreen: {
       title: '🎉 Congratulations!',
-      message: "You've completed the game and mined your Mola Mola Coin!",
-      action: 'Take a screenshot and send it to',
-      social: 'Subscribe to our YouTube and TikTok',
-      comment: 'Write in comments: "I finished the game and mined Mola Mola Coin!"',
+      message: "You've completed the game!",
       copy: 'Copy code',
     },
     stats: {
@@ -43,10 +35,7 @@ export const localization = {
     },
     finishScreen: {
       title: '🎉 Complimenti!',
-      message: 'Hai completato il gioco e minato la tua Mola Mola Coin!',
-      action: 'Fai uno screenshot e invialo a',
-      social: 'Iscriviti al nostro YouTube e TikTok',
-      comment: 'Scrivi nei commenti: "Ho finito il gioco e minato la Mola Mola Coin!"',
+      message: 'Hai completato il gioco!',
       copy: 'Copia codice',
     },
     stats: {
@@ -64,10 +53,7 @@ export const localization = {
     },
     finishScreen: {
       title: '🎉 Поздравляем!',
-      message: 'Вы прошли игру и намайнили свою Mola Mola Coin!',
-      action: 'Сделайте скриншот и отправьте его на',
-      social: 'Подпишитесь на наш YouTube и TikTok',
-      comment: 'Напишите в комментариях: «Я прошёл игру и намайнил Mola Mola Coin!»',
+      message: 'Вы прошли игру!',
       copy: 'Скопировать код',
     },
     stats: {

--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -93,7 +93,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
       await transporter.sendMail({
         from: process.env.SMTP_USER,
-        to: 'CommanderMolaMola@gmail.com',
+        to: process.env.SMTP_USER,
         subject: 'New Player Joined',
         text: `A new player has joined the game! Nickname: ${nickname} Email: ${email}`,
       });

--- a/public/tiktokxALZu5Vzk4n3cZx80f6uIEpTEBZIs1MS.txt
+++ b/public/tiktokxALZu5Vzk4n3cZx80f6uIEpTEBZIs1MS.txt
@@ -1,1 +1,0 @@
-tiktok-developers-site-verification=xALZu5Vzk4n3cZx80f6uIEpTEBZIs1MS

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,6 @@
     {
       "source": "/cornettoclicker/:path*",
       "destination": "/cornettoclicker/:path*"
-    },
-    {
-      "source": "/CommanderMolaMola/:path*",
-      "destination": "/CommanderMolaMola/:path*"
     }
   ],
   "functions": {


### PR DESCRIPTION
## Summary
- strip Commander Mola Mola branding and links from configuration, layout, and finish screen
- drop Commander-specific routes, assets, and vercel rewrites
- update registration email to use environment configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ee5deeae8832ca8d522908b7c5b93