### PR TITLE
Fix SVG icon sizing on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -156,6 +156,15 @@ export default function AzumboLanding() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJson) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(catalogJson) }} />
 
+      <style jsx>{`
+        @media (max-width: 768px) {
+          svg {
+            max-width: 100%;
+            height: auto;
+          }
+        }
+      `}</style>
+
       {/* COMPACT DARK HEADER */}
       <header className="sticky top-0 z-40 border-b border-neutral-800 bg-neutral-950/80 backdrop-blur supports-[backdrop-filter]:bg-neutral-950/60 px-[max(env(safe-area-inset-left),0px)]">
         <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-2">
@@ -221,9 +230,24 @@ export default function AzumboLanding() {
         <div className="mt-10">
           <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-neutral-500">{t.platforms}</h3>
           <div className="mt-3 flex flex-wrap gap-2">
-            <Chip><AndroidIcon className="h-4 w-4" /> {t.android}</Chip>
-            <Chip><AppleIcon className="h-4 w-4" /> {t.ios}</Chip>
-            <Chip><SwitchIcon className="h-4 w-4" /> {t.switch}</Chip>
+            <Chip>
+              <div className="flex items-center justify-center w-4 h-4">
+                <AndroidIcon width="16" height="16" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+              </div>
+              {t.android}
+            </Chip>
+            <Chip>
+              <div className="flex items-center justify-center w-4 h-4">
+                <AppleIcon width="16" height="16" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+              </div>
+              {t.ios}
+            </Chip>
+            <Chip>
+              <div className="flex items-center justify-center w-4 h-4">
+                <SwitchIcon width="16" height="16" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+              </div>
+              {t.switch}
+            </Chip>
           </div>
         </div>
       </section>
@@ -234,13 +258,19 @@ export default function AzumboLanding() {
         <p className="mt-1 max-w-2xl text-sm text-neutral-600 dark:text-neutral-300">{t.servicesSubtitle}</p>
         <div className="mt-6 grid gap-6 sm:grid-cols-3">
           <ServiceCard title={t.srvProtoTitle} desc={t.srvProtoDesc} price={t.srvProtoPrice}>
-            <RocketIcon className="h-5 w-5" />
+            <div className="flex items-center justify-center w-5 h-5">
+              <RocketIcon width="20" height="20" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+            </div>
           </ServiceCard>
           <ServiceCard title={t.srvPublishTitle} desc={t.srvPublishDesc} price={t.srvPublishPrice}>
-            <MegaphoneIcon className="h-5 w-5" />
+            <div className="flex items-center justify-center w-5 h-5">
+              <MegaphoneIcon width="20" height="20" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+            </div>
           </ServiceCard>
           <ServiceCard title={t.srvPortTitle} desc={t.srvPortDesc} price={t.srvPortPrice}>
-            <SwitchIcon className="h-5 w-5" />
+            <div className="flex items-center justify-center w-5 h-5">
+              <SwitchIcon width="20" height="20" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+            </div>
           </ServiceCard>
         </div>
         <div className="mt-5">


### PR DESCRIPTION
## Summary
- Ensure all landing page SVG icons have explicit dimensions and preserveAspectRatio
- Wrap icons with flex containers for consistent sizing and add mobile-friendly SVG styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aacab9ce04832cb7eb592d918bbe7b