### PR TITLE
Fix icon sizing for Safari compatibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,30 +5,37 @@
 :root { --container: 72rem; }
 .container-nx { margin-inline:auto; max-width:var(--container); padding-inline:1rem; }
 a:focus { outline: none; }
-html, body { font-family: var(--font-inter), ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji; }
-
-/* Icon sizing helpers */
-.platform-icon, .service-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.platform-icon svg, .service-icon svg {
-  width: 1em;
-  height: 1em;
-  flex-shrink: 0;
-}
-
-.platform-icon { font-size: 16px; }
-.service-icon { font-size: 20px; }
+html, body { font-family: var(--font-inter), ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, AppleColor Emoji, Segoe UI Emoji; }
 
 svg {
   max-width: 100%;
   height: auto;
 }
 
-@media (max-width: 768px) {
-  .platform-icon { font-size: 14px; }
-  .service-icon { font-size: 18px; }
+/* Icon sizing helpers */
+.platform-icon,
+.service-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
+
+.platform-icon {
+  width: 16px;
+  height: 16px;
+  font-size: 14px;
+}
+
+.service-icon {
+  width: 24px;
+  height: 24px;
+  font-size: 18px;
+}
+
+.platform-icon svg,
+.service-icon svg {
+  width: 100%;
+  height: 100%;
+  flex-shrink: 0;
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -223,19 +223,19 @@ export default function AzumboLanding() {
           <div className="mt-3 flex flex-wrap gap-2">
             <Chip>
               <span className="platform-icon">
-                <AndroidIcon width="16" height="16" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+                <AndroidIcon preserveAspectRatio="xMidYMid meet" fill="currentColor" />
               </span>
               {t.android}
             </Chip>
             <Chip>
               <span className="platform-icon">
-                <AppleIcon width="16" height="16" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+                <AppleIcon preserveAspectRatio="xMidYMid meet" fill="currentColor" />
               </span>
               {t.ios}
             </Chip>
             <Chip>
               <span className="platform-icon">
-                <SwitchIcon width="16" height="16" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+                <SwitchIcon preserveAspectRatio="xMidYMid meet" fill="currentColor" />
               </span>
               {t.switch}
             </Chip>
@@ -250,17 +250,17 @@ export default function AzumboLanding() {
         <div className="mt-6 grid gap-6 sm:grid-cols-3">
           <ServiceCard title={t.srvProtoTitle} desc={t.srvProtoDesc} price={t.srvProtoPrice}>
             <span className="service-icon">
-              <RocketIcon width="20" height="20" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+              <RocketIcon preserveAspectRatio="xMidYMid meet" fill="currentColor" />
             </span>
           </ServiceCard>
           <ServiceCard title={t.srvPublishTitle} desc={t.srvPublishDesc} price={t.srvPublishPrice}>
             <span className="service-icon">
-              <MegaphoneIcon width="20" height="20" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+              <MegaphoneIcon preserveAspectRatio="xMidYMid meet" fill="currentColor" />
             </span>
           </ServiceCard>
           <ServiceCard title={t.srvPortTitle} desc={t.srvPortDesc} price={t.srvPortPrice}>
             <span className="service-icon">
-              <SwitchIcon width="20" height="20" preserveAspectRatio="xMidYMid meet" fill="currentColor" />
+              <SwitchIcon preserveAspectRatio="xMidYMid meet" fill="currentColor" />
             </span>
           </ServiceCard>
         </div>


### PR DESCRIPTION
## Summary
- standardize platform and service icon dimensions
- remove hardcoded SVG dimensions so icons rely on shared CSS sizing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae14f408c832c91bb56294202ca6b