### PR TITLE
Remove obsolete IphoneWrapper wrapper

### DIFF
--- a/pages/cornettoclicker.js
+++ b/pages/cornettoclicker.js
@@ -1,8 +1,7 @@
 import { useEffect } from 'react';
 import Head from 'next/head';
-import IphoneWrapper from '../components/IphoneWrapper';
 
-// Page that wraps the mini game in an iPhone frame on desktop
+// Page that displays the mini game and redirects to the raw HTML on mobile devices
 export default function CornettoClicker() {
   useEffect(() => {
     // On mobile devices open the raw html page
@@ -22,13 +21,11 @@ export default function CornettoClicker() {
           content="xALZu5Vzk4n3cZx80f6uIEpTEBZIs1MS"
         />
       </Head>
-      <IphoneWrapper>
-        <iframe
-          src="/cornettoclicker/game.html"
-          title="Cornetto Clicker"
-          style={{ width: '100%', height: '100%', border: 'none' }}
-        />
-      </IphoneWrapper>
+      <iframe
+        src="/cornettoclicker/game.html"
+        title="Cornetto Clicker"
+        style={{ width: '100%', height: '100%', border: 'none' }}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- remove unused `IphoneWrapper` component from CornettoClicker page
- show Cornetto Clicker game directly in an iframe and update comment

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab29303eb4832c94be4b46408de623