### PR TITLE
Gamify landing page with custom cursor, audio, and animated cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,3 +51,42 @@ svg {
     height: 2.5rem;
   }
 }
+
+/* Custom cursor */
+body {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' shape-rendering='crispEdges'%3E%3Cpath fill='%23fff' stroke='%23000' stroke-width='1' d='M0 0 L0 15 L5 10 L9 14 L11 12 L7 8 L12 8 Z'%2F%3E%3C%2Fsvg%3E") 0 0, auto;
+}
+a:hover, button:hover, .clickable:hover {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' shape-rendering='crispEdges'%3E%3Cpath fill='%23ff0' stroke='%23000' stroke-width='1' d='M0 0 L0 15 L5 10 L9 14 L11 12 L7 8 L12 8 Z'%2F%3E%3C%2Fsvg%3E") 0 0, pointer;
+}
+body.cursor-click {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' shape-rendering='crispEdges'%3E%3Cpath fill='%23f00' stroke='%23000' stroke-width='1' d='M0 0 L0 15 L5 10 L9 14 L11 12 L7 8 L12 8 Z'%2F%3E%3C%2Fsvg%3E") 0 0, auto;
+}
+
+/* Pressable buttons */
+.pressable {
+  transition: transform 0.1s, box-shadow 0.1s;
+  box-shadow: 0 4px 0 rgba(0,0,0,0.6);
+}
+.pressable:active {
+  transform: translateY(2px) scale(0.95);
+  box-shadow: 0 0 0 rgba(0,0,0,0.6);
+}
+
+/* Easter egg */
+.easter-egg {
+  position: fixed;
+  bottom: 8px;
+  left: 8px;
+  width: 16px;
+  height: 16px;
+  background: yellow;
+  opacity: 0;
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width='16' height='16' shape-rendering='crispEdges'%3E%3Cpath fill='%23ff0' stroke='%23000' stroke-width='1' d='M0 0 L0 15 L5 10 L9 14 L11 12 L7 8 L12 8 Z'%2F%3E%3C%2Fsvg%3E") 0 0, pointer;
+}
+.easter-egg:hover { opacity: 1; }
+.easter-egg.found { animation: spin 1s linear infinite; }
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { Inter } from 'next/font/google';
+import GameFX from '../components/GameFX';
 
 const inter = Inter({
   subsets: ['latin', 'cyrillic'],
@@ -33,6 +34,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="h-full">
       <body className={`${inter.variable} min-h-full bg-white text-neutral-900 antialiased dark:bg-neutral-950 dark:text-neutral-100`}>
+        <GameFX />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,6 +118,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
 
 export default function AzumboLanding() {
   const [lang, setLang] = useState<Lang>('en');
+  const [secret, setSecret] = useState(false);
 
   useEffect(() => {
     const saved = window.localStorage.getItem('azumbo-lang') as Lang | null;
@@ -209,13 +210,13 @@ export default function AzumboLanding() {
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
             href="/cornettoclicker"
-            className="rounded-xl bg-black px-5 py-3 text-white shadow-md transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:bg-white dark:text-black dark:focus-visible:outline-white"
+            className="pressable rounded-xl bg-black px-5 py-3 text-white shadow-md transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:bg-white dark:text-black dark:focus-visible:outline-white"
           >
             {t.ctaPlay}
           </Link>
           <a
             href="mailto:azumbogames@gmail.com"
-            className="rounded-xl border border-neutral-300 px-5 py-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:border-neutral-700 dark:focus-visible:outline-white"
+            className="pressable rounded-xl border border-neutral-300 px-5 py-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:border-neutral-700 dark:focus-visible:outline-white"
           >
             {t.ctaContact}
           </a>
@@ -271,7 +272,7 @@ export default function AzumboLanding() {
         <div className="mt-5">
           <a
             href="mailto:azumbogames@gmail.com"
-            className="inline-flex items-center gap-2 rounded-xl bg-black px-4 py-2 text-sm text-white shadow-md transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:bg-white dark:text-black dark:focus-visible:outline-white"
+            className="pressable inline-flex items-center gap-2 rounded-xl bg-black px-4 py-2 text-sm text-white shadow-md transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:bg-white dark:text-black dark:focus-visible:outline-white"
           >
             {t.srvCTA}
           </a>
@@ -288,6 +289,7 @@ export default function AzumboLanding() {
             desc={t.frDesc}
             icon={<FrogIcon className="game-icon" />}
             gradient="from-emerald-500 to-green-600"
+            media="https://media.giphy.com/media/HezU1FQQtq7RO/giphy.gif"
           />
           <GameCard
             href="/Spaceinvaders"
@@ -295,6 +297,7 @@ export default function AzumboLanding() {
             desc={t.siDesc}
             icon={<RocketIcon className="game-icon" />}
             gradient="from-blue-500 to-indigo-600"
+            media="https://media.giphy.com/media/l0ExncehJzexFpRHq/giphy.gif"
           />
           <GameCard
             href="/PacMan"
@@ -302,6 +305,7 @@ export default function AzumboLanding() {
             desc={t.pmDesc}
             icon={<GhostIcon className="game-icon" />}
             gradient="from-yellow-400 to-orange-500"
+            media="https://media.giphy.com/media/HhIuAVM3L2I8E/giphy.gif"
           />
         </div>
       </section>
@@ -326,6 +330,11 @@ export default function AzumboLanding() {
       <footer className="border-t py-6 text-center text-sm dark:border-neutral-800">
         {t.footer}
       </footer>
+      <div
+        className={`easter-egg ${secret ? 'found' : ''}`}
+        onClick={() => setSecret(true)}
+      />
+      {secret && <div className="fixed bottom-20 left-8 text-xs">🎉</div>}
     </main>
   );
 }
@@ -347,13 +356,14 @@ function ServiceCard({ title, desc, price, children }: any) {
     </div>
   );
 }
-function GameCard({ href, title, desc, icon, gradient }: any) {
+function GameCard({ href, title, desc, icon, gradient, media }: any) {
   return (
     <Link
       href={href}
-      className="group flex flex-col rounded-2xl border border-neutral-200 overflow-hidden shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:border-neutral-800 dark:focus-visible:outline-white"
+      className="group pressable flex flex-col rounded-2xl border-4 border-neutral-300 bg-neutral-100 overflow-hidden shadow-md transition-all hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:border-neutral-800 dark:bg-neutral-900 dark:focus-visible:outline-white"
     >
-      <div className={`h-32 bg-gradient-to-br ${gradient} flex items-center justify-center relative`}>
+      <div className={`relative h-32 bg-gradient-to-br ${gradient} flex items-center justify-center`}>
+        <img src={media} alt="" className="absolute inset-0 h-full w-full object-cover opacity-0 group-hover:opacity-100 transition duration-300" />
         <div className="absolute inset-0 opacity-10 bg-pattern"></div>
         <div className="relative z-10 text-white text-4xl">
           {icon}

--- a/components/GameFX.tsx
+++ b/components/GameFX.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useEffect } from 'react';
+import SoundToggle from './SoundToggle';
+import { playAmbientLoop, playClickSound, playHoverSound, mute, unmute } from '../lib/audioManager';
+
+export default function GameFX() {
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const muted = localStorage.getItem('muted') === 'true';
+      muted ? mute() : unmute();
+    }
+    playAmbientLoop();
+    const handleClick = (e: MouseEvent) => {
+      playClickSound();
+    };
+    const handleHover = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('a, button, .clickable')) {
+        playHoverSound();
+      }
+    };
+    const handleDown = () => document.body.classList.add('cursor-click');
+    const handleUp = () => document.body.classList.remove('cursor-click');
+    document.addEventListener('click', handleClick);
+    document.addEventListener('mouseover', handleHover);
+    document.addEventListener('mousedown', handleDown);
+    document.addEventListener('mouseup', handleUp);
+    return () => {
+      document.removeEventListener('click', handleClick);
+      document.removeEventListener('mouseover', handleHover);
+      document.removeEventListener('mousedown', handleDown);
+      document.removeEventListener('mouseup', handleUp);
+    };
+  }, []);
+  return <SoundToggle />;
+}

--- a/components/SoundToggle.tsx
+++ b/components/SoundToggle.tsx
@@ -17,7 +17,11 @@ export default function SoundToggle() {
   };
 
   return (
-    <button className="pixel-button" onClick={handleClick} style={{ position: 'fixed', top: 10, right: 10 }}>
+    <button
+      className="pixel-button pressable"
+      onClick={handleClick}
+      style={{ position: 'fixed', top: 10, right: 10 }}
+    >
       {muted ? '🔇' : '🔊'}
     </button>
   );

--- a/lib/audioManager.ts
+++ b/lib/audioManager.ts
@@ -1,5 +1,6 @@
 let ambient: HTMLAudioElement | null = null;
 let jumpSound: HTMLAudioElement | null = null;
+let audioCtx: AudioContext | null = null;
 let isMuted = false;
 
 export function playAmbientLoop() {
@@ -23,6 +24,36 @@ export function playJumpSound() {
   }
   jumpSound.currentTime = 0;
   jumpSound.play();
+}
+
+function getCtx() {
+  if (!audioCtx) {
+    audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)();
+  }
+  return audioCtx;
+}
+
+function beep(freq: number, duration = 0.1) {
+  if (isMuted) return;
+  const ctx = getCtx();
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'square';
+  osc.frequency.value = freq;
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start();
+  gain.gain.setValueAtTime(0.1, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
+  osc.stop(ctx.currentTime + duration);
+}
+
+export function playClickSound() {
+  beep(220, 0.07);
+}
+
+export function playHoverSound() {
+  beep(440, 0.05);
 }
 
 export function mute() {


### PR DESCRIPTION
## Summary
- Replace cursor image files with inline SVG cursors and add easter-egg pointer
- Showcase games with remote looping GIF covers instead of bundled binaries
- Synthesize click/hover sound effects with Web Audio API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ed7f4b78832ca1d021e95fa7cf76