### PR TITLE
Add static legal and privacy pages

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,3 @@
+# PLACEHOLDER — replace with lines from Unity/LevelPlay dashboard
+# Example format only (do NOT keep this example in production):
+# unity.com, <PUBLISHER_ID>, DIRECT, <SSP_ID>

--- a/public/app-ads.txt
+++ b/public/app-ads.txt
@@ -1,0 +1,3 @@
+# PLACEHOLDER — replace with lines from Unity/LevelPlay dashboard
+# Example format only (do NOT keep this example in production):
+# unity.com, <PUBLISHER_ID>, DIRECT, <SSP_ID>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://azumbo.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://azumbo.vercel.app/</loc><lastmod>2025-09-09</lastmod></url>
+  <url><loc>https://azumbo.vercel.app/legal/privacy</loc><lastmod>2025-09-09</lastmod></url>
+  <url><loc>https://azumbo.vercel.app/legal/terms</loc><lastmod>2025-09-09</lastmod></url>
+  <url><loc>https://azumbo.vercel.app/legal/cookies</loc><lastmod>2025-09-09</lastmod></url>
+  <url><loc>https://azumbo.vercel.app/legal/gdpr-ccpa</loc><lastmod>2025-09-09</lastmod></url>
+  <url><loc>https://azumbo.vercel.app/support</loc><lastmod>2025-09-09</lastmod></url>
+  <url><loc>https://azumbo.vercel.app/redlines/privacy</loc><lastmod>2025-09-09</lastmod></url>
+  <url><loc>https://azumbo.vercel.app/petonauta/privacy</loc><lastmod>2025-09-09</lastmod></url>
+  <url><loc>https://azumbo.vercel.app/cornettoclicker/privacy</loc><lastmod>2025-09-09</lastmod></url>
+</urlset>

--- a/site/assets/logo-azumbo.svg
+++ b/site/assets/logo-azumbo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#111"/>
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">AZ</text>
+</svg>

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,0 +1,20 @@
+:root { --max: 800px; }
+* { box-sizing: border-box; }
+body { margin:0; font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif; color:#222; background:#fff; }
+@media (prefers-color-scheme: dark) {
+  body { color:#eee; background:#0b0b0c; }
+  a { color:#9ecbff; }
+}
+.container { max-width: var(--max); margin: 0 auto; padding: 24px; }
+h1,h2,h3 { line-height:1.2; margin: 0.8em 0 0.4em; }
+header.site { display:flex; align-items:center; gap:12px; margin-bottom:24px; }
+header.site img { width:28px; height:28px; }
+nav a { margin-right: 16px; text-decoration:none; }
+nav { margin: 12px 0 24px; }
+hr { border:none; border-top:1px solid #ddd; margin:24px 0; }
+.tag { display:inline-block; padding:2px 8px; border-radius:999px; background:#eef; color:#334; font-size:12px; }
+@media (prefers-color-scheme: dark) { .tag { background:#152033; color:#cfe1ff; } }
+code,kbd { background:#f3f4f7; padding:2px 6px; border-radius:6px; }
+@media (prefers-color-scheme: dark) { code,kbd { background:#15171a; } }
+.footer-note { font-size: 12px; opacity: .8; }
+.list-inline a { margin-right: 12px; }

--- a/site/cornettoclicker/privacy/index.html
+++ b/site/cornettoclicker/privacy/index.html
@@ -1,0 +1,73 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Cornetto Clicker — Privacy Policy</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+
+<h1>Privacy Policy — Cornetto Clicker</h1>
+<p><span class="tag">Last updated: 2025-09-09</span></p>
+<section>
+  <h2>RU — Политика конфиденциальности</h2>
+  <p>Игра Cornetto Clicker использует рекламные и аналитические SDK для показа и измерения рекламы, а также улучшения продукта. Партнёры могут обрабатывать рекламные идентификаторы устройства (IDFA/GAID), укороченный IP/примерное местоположение, данные об устройстве и события взаимодействия с рекламой.</p>
+  <h3>Основные партнёры</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Настройки</h3>
+  <p>В приложении доступны переключатели: <strong>Settings → Privacy</strong>.</p>
+  <h3>Контакты</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<hr>
+<section>
+  <h2>EN — Privacy Policy</h2>
+  <p>Cornetto Clicker uses advertising and analytics SDKs to serve/measure ads and improve the product. Partners may process device advertising identifiers (IDFA/GAID), truncated IP/coarse location, device data, and ad interaction events.</p>
+  <h3>Main partners</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Controls</h3>
+  <p>Switches available in app: <strong>Settings → Privacy</strong>.</p>
+  <h3>Contact</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<hr>
+<section>
+  <h2>IT — Informativa sulla privacy</h2>
+  <p>Cornetto Clicker utilizza SDK pubblicitari e di analisi per mostrare/misurare gli annunci e migliorare il prodotto. I partner possono trattare identificatori pubblicitari del dispositivo (IDFA/GAID), IP troncato/posizione approssimativa, dati del dispositivo ed eventi di interazione con gli annunci.</p>
+  <h3>Partner principali</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Controlli</h3>
+  <p>Nell’app sono disponibili interruttori: <strong>Settings → Privacy</strong>.</p>
+  <h3>Contatti</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,25 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AZUMBO</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+<h1>AZUMBO Website</h1>
+<p>Select a page from the navigation above.</p>
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/site/legal/cookies/index.html
+++ b/site/legal/cookies/index.html
@@ -1,0 +1,40 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AZUMBO — Cookie Policy</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+
+<h1>Cookie Policy — AZUMBO</h1>
+<p><span class="tag">Last updated: 2025-09-09</span></p>
+<section>
+  <h2>RU — Политика в отношении cookies</h2>
+  <p>Этот сайт использует только технические cookies для корректной работы (например, запоминание языка). Рекламные и аналитические технологии используются лишь внутри наших игр, подчиняясь их политикам.</p>
+</section>
+<hr>
+<section>
+  <h2>EN — Cookie Policy</h2>
+  <p>This site uses only technical cookies necessary for proper operation (e.g., remembering language). Advertising and analytics technologies are used only inside our games, governed by their own policies.</p>
+</section>
+<hr>
+<section>
+  <h2>IT — Politica sui cookie</h2>
+  <p>Questo sito utilizza solo cookie tecnici necessari al funzionamento (ad es. ricordare la lingua). Le tecnologie pubblicitarie e di analisi sono usate solo all'interno dei nostri giochi, secondo le rispettive informative.</p>
+</section>
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/site/legal/gdpr-ccpa/index.html
+++ b/site/legal/gdpr-ccpa/index.html
@@ -1,0 +1,43 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AZUMBO — GDPR/CCPA Notice</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+
+<h1>GDPR / CCPA — AZUMBO</h1>
+<p><span class="tag">Last updated: 2025-09-09</span></p>
+<section>
+  <h2>RU — Ваши права</h2>
+  <p>В соответствии с GDPR и CCPA у вас есть право на доступ, исправление, удаление, ограничение обработки и отказ от продажи/обмена данных. В играх вы можете управлять персонализацией рекламы и опцией «Do Not Sell/Share» через меню <strong>Settings → Privacy</strong>.</p>
+  <p>Для запросов свяжитесь по <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.</p>
+</section>
+<hr>
+<section>
+  <h2>EN — Your Rights</h2>
+  <p>Under GDPR and CCPA you have rights to access, rectify, delete or restrict processing of your data and to opt out of sale/share. In our games you can control Personalized Ads and Do Not Sell/Share via <strong>Settings → Privacy</strong>.</p>
+  <p>For requests contact <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.</p>
+</section>
+<hr>
+<section>
+  <h2>IT — I tuoi diritti</h2>
+  <p>Ai sensi del GDPR e del CCPA hai diritto di accesso, rettifica, cancellazione, limitazione del trattamento e di opt-out dalla vendita/condivisione dei dati. Nei giochi puoi gestire Annunci personalizzati e Do Not Sell/Share tramite <strong>Settings → Privacy</strong>.</p>
+  <p>Per richieste contatta <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>.</p>
+</section>
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/site/legal/privacy/index.html
+++ b/site/legal/privacy/index.html
@@ -1,0 +1,88 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AZUMBO — Privacy Policy</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+
+<h1>Privacy Policy — AZUMBO</h1>
+<p><span class="tag">Last updated: 2025-09-09</span></p>
+
+<section>
+  <h2>RU — Политика конфиденциальности</h2>
+  <p>Студия AZUMBO выпускает мобильные игры и сайты. Мы используем рекламные и аналитические SDK для показа и измерения рекламы, а также улучшения продуктов. Сторонние партнёры могут обрабатывать рекламные идентификаторы устройства (IDFA/GAID), укороченный IP/примерное местоположение (страна/регион), данные об устройстве/ОС/языке, события взаимодействия с рекламой (показ, клик, установка).</p>
+  <p>Мы не собираем напрямую ФИО, адрес электронной почты или почтовый адрес без вашего действия (например, если вы напишите нам письмо).</p>
+  <h3>Основные партнёры</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>GDPR / CCPA</h3>
+  <p>В играх доступны настройки приватности: персонализированная реклама (GDPR) и «Do Not Sell/Share» (CCPA/CPRA). Управляйте ими в меню игры: <strong>Settings → Privacy</strong>.</p>
+  <h3>Дети</h3>
+  <p>Наши игры не нацелены на детей младше 13 лет. Если вы считаете, что данные ребёнка были собраны, свяжитесь с нами — мы удалим такую информацию.</p>
+  <h3>Контакты</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+
+<hr>
+
+<section>
+  <h2>EN — Privacy Policy</h2>
+  <p>AZUMBO publishes mobile games and websites. We use advertising and analytics SDKs to serve/measure ads and improve our products. Third-party partners may process device advertising identifiers (IDFA/GAID), truncated IP / coarse location (country/region), device/OS/language data, and ad interaction events (impressions, clicks, installs).</p>
+  <p>We do not directly collect your name, email, or postal address unless you actively provide it (e.g., emailing us).</p>
+  <h3>Main partners</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>GDPR / CCPA</h3>
+  <p>In our games, privacy controls are available: Personalized Ads (GDPR) and Do Not Sell/Share (CCPA/CPRA). Use <strong>Settings → Privacy</strong> in the app.</p>
+  <h3>Children</h3>
+  <p>Our apps are not directed to children under 13. If you believe a child’s data was collected, contact us and we will delete it.</p>
+  <h3>Contact</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+
+<hr>
+
+<section>
+  <h2>IT — Informativa sulla privacy</h2>
+  <p>AZUMBO pubblica giochi mobile e siti web. Utilizziamo SDK pubblicitari e di analisi per mostrare/misurare gli annunci e migliorare i nostri prodotti. I partner terzi possono trattare identificatori pubblicitari del dispositivo (IDFA/GAID), IP troncato/posizione approssimativa (paese/regione), dati di dispositivo/OS/lingua ed eventi di interazione con gli annunci (impressioni, clic, installazioni).</p>
+  <p>Non raccogliamo direttamente nome, email o indirizzo postale a meno che non ce li forniate volontariamente.</p>
+  <h3>Partner principali</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>GDPR / CCPA</h3>
+  <p>Nei giochi sono disponibili controlli privacy: Annunci personalizzati (GDPR) e Do Not Sell/Share (CCPA/CPRA). Usare <strong>Settings → Privacy</strong> nell’app.</p>
+  <h3>Bambini</h3>
+  <p>Le nostre app non sono destinate ai minori di 13 anni. Per qualsiasi dubbio, contattateci: elimineremo i dati.</p>
+  <h3>Contatti</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/site/legal/terms/index.html
+++ b/site/legal/terms/index.html
@@ -1,0 +1,40 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AZUMBO — Terms of Use</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+
+<h1>Terms of Use — AZUMBO</h1>
+<p><span class="tag">Last updated: 2025-09-09</span></p>
+<section>
+  <h2>RU — Условия использования</h2>
+  <p>Используя сайты и игры AZUMBO, вы соглашаетесь соблюдать законы и не нарушать права других пользователей. Контент предоставляется «как есть». Мы можем обновлять приложения без уведомления.</p>
+</section>
+<hr>
+<section>
+  <h2>EN — Terms of Use</h2>
+  <p>By using AZUMBO sites and games, you agree to follow the law and respect other users. Content is provided “as is”. We may update the apps without notice.</p>
+</section>
+<hr>
+<section>
+  <h2>IT — Termini di utilizzo</h2>
+  <p>Utilizzando i siti e i giochi AZUMBO accetti di rispettare la legge e gli altri utenti. Il contenuto è fornito “così com'è”. Possiamo aggiornare le app senza preavviso.</p>
+</section>
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/site/petonauta/privacy/index.html
+++ b/site/petonauta/privacy/index.html
@@ -1,0 +1,73 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Petonauta Afozio — Privacy Policy</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+
+<h1>Privacy Policy — Petonauta Afozio</h1>
+<p><span class="tag">Last updated: 2025-09-09</span></p>
+<section>
+  <h2>RU — Политика конфиденциальности</h2>
+  <p>Игра Petonauta Afozio использует рекламные и аналитические SDK для показа и измерения рекламы, а также улучшения продукта. Партнёры могут обрабатывать рекламные идентификаторы устройства (IDFA/GAID), укороченный IP/примерное местоположение, данные об устройстве и события взаимодействия с рекламой.</p>
+  <h3>Основные партнёры</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Настройки</h3>
+  <p>В приложении доступны переключатели: <strong>Settings → Privacy</strong>.</p>
+  <h3>Контакты</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<hr>
+<section>
+  <h2>EN — Privacy Policy</h2>
+  <p>Petonauta Afozio uses advertising and analytics SDKs to serve/measure ads and improve the product. Partners may process device advertising identifiers (IDFA/GAID), truncated IP/coarse location, device data, and ad interaction events.</p>
+  <h3>Main partners</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Controls</h3>
+  <p>Switches available in app: <strong>Settings → Privacy</strong>.</p>
+  <h3>Contact</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<hr>
+<section>
+  <h2>IT — Informativa sulla privacy</h2>
+  <p>Petonauta Afozio utilizza SDK pubblicitari e di analisi per mostrare/misurare gli annunci e migliorare il prodotto. I partner possono trattare identificatori pubblicitari del dispositivo (IDFA/GAID), IP troncato/posizione approssimativa, dati del dispositivo ed eventi di interazione con gli annunci.</p>
+  <h3>Partner principali</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Controlli</h3>
+  <p>Nell’app sono disponibili interruttori: <strong>Settings → Privacy</strong>.</p>
+  <h3>Contatti</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/site/redlines/privacy/index.html
+++ b/site/redlines/privacy/index.html
@@ -1,0 +1,73 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Red Lines — Privacy Policy</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+
+<h1>Privacy Policy — Red Lines</h1>
+<p><span class="tag">Last updated: 2025-09-09</span></p>
+<section>
+  <h2>RU — Политика конфиденциальности</h2>
+  <p>Игра Red Lines использует рекламные и аналитические SDK для показа и измерения рекламы, а также улучшения продукта. Партнёры могут обрабатывать рекламные идентификаторы устройства (IDFA/GAID), укороченный IP/примерное местоположение, данные об устройстве и события взаимодействия с рекламой.</p>
+  <h3>Основные партнёры</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Настройки</h3>
+  <p>В приложении доступны переключатели: <strong>Settings → Privacy</strong>.</p>
+  <h3>Контакты</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<hr>
+<section>
+  <h2>EN — Privacy Policy</h2>
+  <p>Red Lines uses advertising and analytics SDKs to serve/measure ads and improve the product. Partners may process device advertising identifiers (IDFA/GAID), truncated IP/coarse location, device data, and ad interaction events.</p>
+  <h3>Main partners</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Controls</h3>
+  <p>Switches available in app: <strong>Settings → Privacy</strong>.</p>
+  <h3>Contact</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<hr>
+<section>
+  <h2>IT — Informativa sulla privacy</h2>
+  <p>Red Lines utilizza SDK pubblicitari e di analisi per mostrare/misurare gli annunci e migliorare il prodotto. I partner possono trattare identificatori pubblicitari del dispositivo (IDFA/GAID), IP troncato/posizione approssimativa, dati del dispositivo ed eventi di interazione con gli annunci.</p>
+  <h3>Partner principali</h3>
+  <ul>
+    <li>Unity LevelPlay / Unity Ads (ironSource):
+      <a href="https://unity.com/legal/iron-source-privacy-policy">ironSource Privacy Policy</a> ·
+      <a href="https://unity.com/legal/privacy-policy">Unity Privacy Policy</a>
+    </li>
+  </ul>
+  <h3>Controlli</h3>
+  <p>Nell’app sono disponibili interruttori: <strong>Settings → Privacy</strong>.</p>
+  <h3>Contatti</h3>
+  <p>Email: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+</section>
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/site/support/index.html
+++ b/site/support/index.html
@@ -1,0 +1,55 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AZUMBO — Support</title>
+<link rel="stylesheet" href="/site/assets/styles.css">
+</head><body><main class="container">
+<header class="site">
+  <img src="/site/assets/logo-azumbo.svg" alt="AZUMBO" />
+  <strong>AZUMBO</strong>
+</header>
+<nav>
+  <a href="/legal/privacy">Privacy</a>
+  <a href="/legal/terms">Terms</a>
+  <a href="/legal/cookies">Cookies</a>
+  <a href="/legal/gdpr-ccpa">GDPR/CCPA</a>
+  <a href="/support">Support</a>
+  <span class="list-inline">
+    <a href="/redlines/privacy">Red Lines Privacy</a>
+    <a href="/petonauta/privacy">Petonauta Privacy</a>
+    <a href="/cornettoclicker/privacy">Cornetto Privacy</a>
+  </span>
+</nav>
+
+<h1>Support — AZUMBO</h1>
+<p><span class="tag">Last updated: 2025-09-09</span></p>
+<section>
+  <h2>RU — Поддержка</h2>
+  <p>Свяжитесь с нами: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+  <h3>FAQ</h3>
+  <ul>
+    <li>Как открыть настройки приватности в игре? — Меню <strong>Settings → Privacy</strong>.</li>
+    <li>Как отключить персонализированную рекламу? — В настройках приватности отключите переключатель Personalized Ads.</li>
+  </ul>
+</section>
+<hr>
+<section>
+  <h2>EN — Support</h2>
+  <p>Contact us: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+  <h3>FAQ</h3>
+  <ul>
+    <li>How to open privacy settings in the game? — Use <strong>Settings → Privacy</strong>.</li>
+    <li>How to disable personalized ads? — In Privacy settings toggle off Personalized Ads.</li>
+  </ul>
+</section>
+<hr>
+<section>
+  <h2>IT — Supporto</h2>
+  <p>Contattaci: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+  <h3>FAQ</h3>
+  <ul>
+    <li>Come aprire le impostazioni privacy nel gioco? — Menu <strong>Settings → Privacy</strong>.</li>
+    <li>Come disattivare gli annunci personalizzati? — Nelle impostazioni Privacy disattiva Personalized Ads.</li>
+  </ul>
+</section>
+<p class="footer-note">© AZUMBO</p>
+</main></body></html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,22 +1,21 @@
 {
+  "cleanUrls": true,
+  "redirects": [],
   "rewrites": [
-    {
-      "source": "/cornettoclicker/:path*",
-      "destination": "/cornettoclicker/:path*"
-    }
+    { "source": "/cornettoclicker/:path*", "destination": "/cornettoclicker/:path*" },
+    { "source": "/", "destination": "/site/index.html" },
+    { "source": "/legal/privacy", "destination": "/site/legal/privacy/index.html" },
+    { "source": "/legal/terms", "destination": "/site/legal/terms/index.html" },
+    { "source": "/legal/cookies", "destination": "/site/legal/cookies/index.html" },
+    { "source": "/legal/gdpr-ccpa", "destination": "/site/legal/gdpr-ccpa/index.html" },
+    { "source": "/support", "destination": "/site/support/index.html" },
+    { "source": "/redlines/privacy", "destination": "/site/redlines/privacy/index.html" },
+    { "source": "/petonauta/privacy", "destination": "/site/petonauta/privacy/index.html" },
+    { "source": "/cornettoclicker/privacy", "destination": "/site/cornettoclicker/privacy/index.html" }
   ],
   "functions": {
-    "pages/api/register.ts": {
-      "maxDuration": 10,
-      "memory": 128
-    },
-    "pages/api/submit-score.ts": {
-      "maxDuration": 10,
-      "memory": 128
-    },
-    "pages/api/stats.ts": {
-      "maxDuration": 10,
-      "memory": 128
-    }
+    "pages/api/register.ts": { "maxDuration": 10, "memory": 128 },
+    "pages/api/submit-score.ts": { "maxDuration": 10, "memory": 128 },
+    "pages/api/stats.ts": { "maxDuration": 10, "memory": 128 }
   }
 }


### PR DESCRIPTION
## Summary
- add static site with legal, support and game privacy pages
- wire Vercel rewrites and public files for robots, sitemap, ads placeholders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08d93ad28832ca9bd61232f51bc4a