### PR TITLE
Add Red Lines public docs

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,3 +1,4 @@
-# PLACEHOLDER — replace with lines from Unity/LevelPlay dashboard
-# Example format only (do NOT keep this example in production):
-# unity.com, <PUBLISHER_ID>, DIRECT, <SSP_ID>
+# Placeholder — replace before production.
+# If using ironSource LevelPlay mediation: copy the aggregated ads.txt from the LevelPlay Ads.txt Manager.
+# If using AdMob directly (example):
+# google.com, pub-XXXXXXXXXXXXXXXX, DIRECT, f08c47fec0942fa0

--- a/public/app-ads.txt
+++ b/public/app-ads.txt
@@ -1,3 +1,2 @@
-# PLACEHOLDER — replace with lines from Unity/LevelPlay dashboard
-# Example format only (do NOT keep this example in production):
-# unity.com, <PUBLISHER_ID>, DIRECT, <SSP_ID>
+# Placeholder — replace before production.
+# Mirror entries from ads.txt unless instructed otherwise by your ad network.

--- a/public/redlines-privacy.html
+++ b/public/redlines-privacy.html
@@ -1,0 +1,43 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Privacy Policy — Red Lines (AZUMBO)</title>
+<meta name="description" content="Privacy Policy for the mobile game Red Lines by AZUMBO (EN/IT/RU).">
+<meta name="robots" content="index,follow">
+<link rel="icon" href="data:,">
+<style>
+  body{margin:0;font:16px/1.5 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;padding:20px;max-width:900px}
+  h1{margin:0 0 8px} h2{margin-top:28px}
+  nav a{margin-right:12px;color:#e11d48;text-decoration:none}
+  .muted{color:#666} .lang{margin-top:12px}
+  @media (prefers-color-scheme: dark){body{background:#0b0b0c;color:#f2f2f3}}
+</style>
+</head><body>
+  <nav><a href="/">AZUMBO</a></nav>
+  <h1>Privacy Policy — <em>Red Lines</em></h1>
+  <p class="muted">Developer: AZUMBO · Contact: <a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+  <p class="lang">Languages: <a href="#en">EN</a> · <a href="#it">IT</a> · <a href="#ru">RU</a></p>
+
+  <section id="en">
+    <h2>EN</h2>
+    <p><strong>App:</strong> Red Lines (mobile game). <strong>Developer:</strong> AZUMBO (<a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>).</p>
+    <p>The app itself does not collect personal data. Third-party advertising/analytics SDKs (e.g., Unity LevelPlay mediation partners) may process device identifiers to deliver ads and measure performance. You can limit ad tracking in your device settings.</p>
+    <p>This policy applies only to Red Lines. For general company contacts, use the email above.</p>
+  </section>
+
+  <section id="it">
+    <h2>IT</h2>
+    <p><strong>App:</strong> Red Lines (gioco mobile). <strong>Sviluppatore:</strong> AZUMBO (<a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>).</p>
+    <p>L’app non raccoglie dati personali. SDK di terze parti per pubblicità/analisi (es. partner di mediazione Unity LevelPlay) possono trattare identificatori del dispositivo per mostrare annunci e misurarne le prestazioni. Puoi limitare il tracciamento degli annunci nelle impostazioni del dispositivo.</p>
+    <p>Questa informativa si applica solo a Red Lines.</p>
+  </section>
+
+  <section id="ru">
+    <h2>RU</h2>
+    <p><strong>Приложение:</strong> Red Lines (мобильная игра). <strong>Разработчик:</strong> AZUMBO (<a href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a>).</p>
+    <p>Игра сама по себе не собирает персональные данные. Сторонние рекламные/аналитические SDK (например, партнёры медиатора Unity LevelPlay) могут обрабатывать идентификаторы устройства для показа рекламы и измерения её эффективности. Вы можете ограничить отслеживание рекламы в настройках устройства.</p>
+    <p>Эта политика применяется только к Red Lines.</p>
+  </section>
+
+  <hr>
+  <p class="muted">© AZUMBO</p>
+</body></html>

--- a/public/support.html
+++ b/public/support.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Support — AZUMBO</title>
+<meta name="description" content="Contact support for AZUMBO games.">
+<style>body{margin:0;font:16px/1.5 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;padding:20px;max-width:900px}
+@media (prefers-color-scheme: dark){body{background:#0b0b0c;color:#f2f2f3}} .btn{display:inline-block;padding:12px 16px;background:#e11d48;color:#fff;border-radius:10px;text-decoration:none}</style>
+</head><body>
+  <h1>Support</h1>
+  <p>Questions or feedback about Red Lines?</p>
+  <p><a class="btn" href="mailto:azumbogames@gmail.com">azumbogames@gmail.com</a></p>
+  <p>We typically reply within a few business days.</p>
+</body></html>


### PR DESCRIPTION
## Summary
- add LevelPlay placeholders in ads.txt and app-ads.txt
- add Red Lines privacy policy and support pages

## Testing
- `npm test`
- `python3 -m http.server 8123` then `curl -I http://localhost:8123/ads.txt`
- `python3 -m http.server 8123` then `curl -I http://localhost:8123/app-ads.txt`
- `python3 -m http.server 8123` then `curl -I http://localhost:8123/redlines-privacy.html`
- `python3 -m http.server 8123` then `curl -I http://localhost:8123/support.html`


------
https://chatgpt.com/codex/tasks/task_e_68c123899cfc832cb5025477a91ef60a