### PR TITLE
Add premium responsive /Azumbox landing page with EN/IT/RU localization

### DIFF
--- a/app/Azumbox/page.tsx
+++ b/app/Azumbox/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type Lang = 'en' | 'it' | 'ru';
+
+type LocalizedCopy = {
+  nav: string;
+  headline: string;
+  description: string;
+  videoLabel: string;
+  videoHint: string;
+  vibeItems: { title: string; text: string }[];
+  cta: string;
+};
+
+const COPY: Record<Lang, LocalizedCopy> = {
+  en: {
+    nav: 'Language',
+    headline: 'Azumbox — the mobile game for people who call chaos “curated spontaneity.”',
+    description:
+      'A polished little escape designed for calm minds and clever smiles. Think smooth pacing, tasteful visuals, and just enough strategy to feel brilliant before breakfast.',
+    videoLabel: 'Demo Preview',
+    videoHint: 'Trailer dropping soon',
+    vibeItems: [
+      {
+        title: 'Quiet Luxury',
+        text: 'Clean visual rhythm, soft contrast, and details that feel intentionally understated.',
+      },
+      {
+        title: 'Calm Intelligence',
+        text: 'Thoughtful mechanics that reward focus, not frenzy.',
+      },
+      {
+        title: 'Pocket Retreat',
+        text: 'A relaxing ritual for commutes, coffee breaks, and elegant procrastination.',
+      },
+    ],
+    cta: 'Download Azumbox',
+  },
+  it: {
+    nav: 'Lingua',
+    headline: 'Azumbox — il gioco mobile per chi chiama il caos “spontaneità curata”.',
+    description:
+      'Una piccola fuga raffinata, pensata per menti calme e sorrisi intelligenti. Ritmo fluido, estetica elegante e la giusta strategia per sentirsi brillanti già al mattino.',
+    videoLabel: 'Anteprima Demo',
+    videoHint: 'Trailer in arrivo',
+    vibeItems: [
+      {
+        title: 'Lusso Silenzioso',
+        text: 'Ritmo visivo pulito, contrasti morbidi e dettagli volutamente essenziali.',
+      },
+      {
+        title: 'Intelligenza Calma',
+        text: 'Meccaniche studiate per premiare concentrazione, non frenesia.',
+      },
+      {
+        title: 'Rifugio Tascabile',
+        text: 'Un rituale rilassante per tragitti, pause caffè e procrastinazione di classe.',
+      },
+    ],
+    cta: 'Scarica Azumbox',
+  },
+  ru: {
+    nav: 'Язык',
+    headline: 'Azumbox — мобильная игра для тех, кто называет хаос «изящной импровизацией».',
+    description:
+      'Стильный мини-отдых для спокойного ума и умной улыбки. Плавный ритм, чистая эстетика и ровно столько стратегии, чтобы почувствовать себя гением до завтрака.',
+    videoLabel: 'Демо-превью',
+    videoHint: 'Трейлер скоро',
+    vibeItems: [
+      {
+        title: 'Тихая Роскошь',
+        text: 'Чистый визуальный ритм, мягкий контраст и намеренно сдержанные детали.',
+      },
+      {
+        title: 'Спокойный Интеллект',
+        text: 'Продуманные механики, где важны внимание и вкус, а не спешка.',
+      },
+      {
+        title: 'Карманный Ретрит',
+        text: 'Расслабляющий ритуал для дороги, кофе-брейков и элегантного отдыха.',
+      },
+    ],
+    cta: 'Скачать Azumbox',
+  },
+};
+
+export default function AzumboxPage() {
+  const [lang, setLang] = useState<Lang>('en');
+  const t = useMemo(() => COPY[lang], [lang]);
+
+  return (
+    <main className="min-h-[100dvh] bg-white text-neutral-900">
+      <div className="container-nx flex min-h-[100dvh] flex-col px-4 py-6 sm:py-8 md:py-10">
+        <header className="flex items-center justify-between border-b border-neutral-200 pb-4">
+          <span className="text-sm uppercase tracking-[0.14em] text-neutral-500">Azumbox</span>
+          <nav aria-label="Language switcher" className="flex items-center gap-2">
+            <span className="hidden text-xs text-neutral-500 sm:inline">{t.nav}</span>
+            {(['en', 'it', 'ru'] as Lang[]).map((code) => {
+              const isActive = code === lang;
+              return (
+                <button
+                  key={code}
+                  type="button"
+                  onClick={() => setLang(code)}
+                  className={`rounded-full border px-3 py-1.5 text-xs tracking-wide transition-all duration-300 ${
+                    isActive
+                      ? 'border-neutral-900 bg-neutral-900 text-white shadow-[0_8px_20px_rgba(0,0,0,0.12)]'
+                      : 'border-neutral-200 bg-white text-neutral-600 hover:border-neutral-400 hover:text-neutral-900'
+                  }`}
+                  aria-pressed={isActive}
+                >
+                  {code.toUpperCase()}
+                </button>
+              );
+            })}
+          </nav>
+        </header>
+
+        <section className="mx-auto flex w-full max-w-4xl flex-1 flex-col justify-center py-12 sm:py-16 md:py-20">
+          <p className="text-xs uppercase tracking-[0.2em] text-neutral-400">Mobile game landing</p>
+          <h1 className="mt-5 text-3xl font-semibold leading-tight text-neutral-950 sm:text-5xl md:text-6xl">
+            {t.headline}
+          </h1>
+          <p className="mt-6 max-w-2xl text-base leading-relaxed text-neutral-600 sm:text-lg">{t.description}</p>
+
+          <div className="group relative mt-10 overflow-hidden rounded-3xl border border-neutral-200 bg-gradient-to-b from-neutral-50 to-white shadow-[0_24px_60px_rgba(10,10,10,0.08)]">
+            <div className="aspect-video w-full" />
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_70%_20%,rgba(255,255,255,0.6),transparent_45%)]" />
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
+              <span className="rounded-full border border-white/70 bg-white/80 px-3 py-1 text-[11px] uppercase tracking-[0.16em] text-neutral-500 backdrop-blur-sm">
+                {t.videoLabel}
+              </span>
+              <button
+                type="button"
+                className="rounded-full border border-neutral-200 bg-white px-5 py-3 text-sm font-medium text-neutral-800 shadow-[0_10px_30px_rgba(0,0,0,0.12)] transition-transform duration-300 group-hover:scale-105"
+              >
+                ▶ Play
+              </button>
+              <span className="text-sm text-neutral-500">{t.videoHint}</span>
+            </div>
+          </div>
+
+          <section className="mt-12 grid gap-4 sm:grid-cols-3">
+            {t.vibeItems.map((item, idx) => (
+              <article
+                key={item.title}
+                className="rounded-2xl border border-neutral-200 p-5 transition duration-300 hover:shadow-[0_16px_35px_rgba(0,0,0,0.06)]"
+              >
+                <span className="text-sm text-neutral-400">0{idx + 1}</span>
+                <h2 className="mt-2 text-lg font-medium">{item.title}</h2>
+                <p className="mt-2 text-sm leading-relaxed text-neutral-600">{item.text}</p>
+              </article>
+            ))}
+          </section>
+
+          <div className="mt-10">
+            <button
+              type="button"
+              className="rounded-full bg-neutral-900 px-8 py-3 text-sm font-medium text-white shadow-[0_16px_35px_rgba(0,0,0,0.2)] transition-all duration-300 hover:-translate-y-0.5 hover:bg-neutral-800"
+            >
+              {t.cta}
+            </button>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated, premium-feeling landing page for the mobile game Azumbox at the `/Azumbox` route. 
- Match the existing site's neutral, minimalist design system and global utility classes while keeping the layout whitespace-forward and refined. 
- Offer simple in-page localization to switch content between English, Italian and Russian for marketing and preview purposes.

### Description
- Added a new client-rendered page at `app/Azumbox/page.tsx` implementing the full landing layout (hero, video placeholder, features/vibe cards, and CTA). 
- Implemented a compact language switcher using `useState` and `useMemo` with localized placeholder copy for `en`, `it`, and `ru`. 
- Built a responsive, framed video container with rounded corners, soft shadow, overlay label and a Play overlay button, plus subtle hover/transition micro-animations. 
- Reused site utilities and spacing (`container-nx`, neutral palette, Tailwind classes) to ensure visual parity and responsiveness across mobile and desktop.

### Testing
- Ran a production build via `npm run build`, which completed successfully (build warnings were non-blocking). 
- Confirmed the new route is present in the Next.js build output as `/Azumbox` and the application compiles without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea830995c4832c80861be7caa9bedc)