### PR TITLE
Fix homepage Bird Lines video link and locale switching

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -53,6 +53,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     birdDescription: `Bird Lines is more than a game; it is a match-3 journey inspired by the story 'City In The Plane' Experience a meditative trip through Paris with Ellie, where puzzles meet storytelling.`,
     birdStatus: 'Status: In Development (Calabria, Italy)',
     waitlistCTA: 'Join the Waitlist',
+    videoLinkLabel: 'Open video link',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
     pressLine: 'For publishers & press: AzumboGames@gmail.com'
@@ -96,6 +97,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     birdDescription: `Bird Lines è un match-3 ispirato alla storia 'City In The Plane' Un viaggio attraverso Parigi insieme ad Ellie, la protagonista del libro, dove il puzzle incontra la narrazione.`,
     birdStatus: 'Stato: In sviluppo (Calabria, Italia)',
     waitlistCTA: 'Unisciti alla Waitlist',
+    videoLinkLabel: 'Apri link video',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
     pressLine: 'Per editori e stampa: AzumboGames@gmail.com'
@@ -139,6 +141,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     birdDescription: `Bird Lines — это match-3 по мотивам истории 'City In The Plane' Путешествие по Парижу вместе с Элли, где механика пазла переплетается с сюжетом книги.`,
     birdStatus: 'Статус: В разработке (Калабрия, Италия)',
     waitlistCTA: 'В лист ожидания',
+    videoLinkLabel: 'Открыть ссылку на видео',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
     pressLine: 'Для издателей и прессы: AzumboGames@gmail.com'
@@ -315,6 +318,14 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
               <video className="mx-auto h-72 rounded-2xl shadow-lg" controls preload="metadata">
                 <source src="/whoops-video.mp4#t=2" type="video/mp4" />
               </video>
+              <a
+                href="https://github.com/Azumbo/Azumbo/blob/main/public/WhoopsBirdLines.mp4"
+                target="_blank"
+                rel="noreferrer"
+                className="mt-4 block text-center text-sm font-medium text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+              >
+                {t.videoLinkLabel}
+              </a>
             </div>
             <div className="p-8 md:w-2/3">
               <h3 className="text-2xl font-bold uppercase tracking-wider">{t.birdTitle}</h3>

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,11 +30,7 @@ export function middleware(request: NextRequest) {
   const localeMatch = pathname.match(/^\/(en|ru|it)(\/.*)?$/);
   if (localeMatch) {
     const locale = localeMatch[1];
-    const strippedPath = localeMatch[2] || '/';
-    const rewriteUrl = request.nextUrl.clone();
-    rewriteUrl.pathname = strippedPath;
-
-    const response = NextResponse.rewrite(rewriteUrl);
+    const response = NextResponse.next();
     response.cookies.set('azumbo_locale', locale, {
       path: '/',
       sameSite: 'lax',


### PR DESCRIPTION
### Motivation
- Make the Bird Lines source video discoverable from the homepage and provide a localized CTA for opening the source file. 
- Ensure locale URLs actually load the localized pages while still persisting the chosen locale in a cookie instead of rewriting back to `/`.

### Description
- Update `middleware.ts` to stop rewriting `/(en|it|ru)` paths back to `/` and instead return `NextResponse.next()` while setting the `azumbo_locale` cookie. 
- Add localized `videoLinkLabel` strings for `en`, `it`, and `ru` in `app/[locale]/page.tsx`. 
- Render a visible external anchor under the Bird Lines video that opens `https://github.com/Azumbo/Azumbo/blob/main/public/WhoopsBirdLines.mp4` in a new tab and uses the localized label.

### Testing
- Ran `npm run build` which completed successfully and generated the static pages without build errors. 
- Verified the modified files `app/[locale]/page.tsx` and `middleware.ts` compile as part of the build process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8c756c20832cb215ff3478640d65)