### PR TITLE
Refine Azumbox video section for vertical mobile frame

### DIFF
--- a/app/azumbox/page.tsx
+++ b/app/azumbox/page.tsx
@@ -126,16 +126,26 @@ export default function AzumboxPage() {
           <p className="mt-6 max-w-2xl text-base leading-relaxed text-neutral-600 sm:text-lg">{t.description}</p>
 
           {/* Видео-контейнер */}
-          <div className="mt-10 overflow-hidden rounded-3xl border border-neutral-100 bg-neutral-50 shadow-[0_24px_60px_rgba(0,0,0,0.07)]">
-            <video autoPlay loop muted playsInline className="aspect-video w-full object-cover">
-              <source src="/azumbox-demo.mp4" type="video/mp4" />
-              Your browser does not support the video tag.
-            </video>
+          <div className="mx-auto mt-10 w-full max-w-[24rem]">
+            <div className="rounded-[2.2rem] border border-neutral-800/60 bg-neutral-900 p-1.5 shadow-[0_28px_75px_rgba(24,24,27,0.3)]">
+              <div className="overflow-hidden rounded-[1.8rem] border border-white/10 bg-neutral-50">
+                <video
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                  className="aspect-[9/16] max-h-[70vh] w-full object-cover"
+                >
+                  <source src="/azumbox-demo.mp4" type="video/mp4" />
+                  Your browser does not support the video tag.
+                </video>
+              </div>
+            </div>
           </div>
 
-          <section className="mt-12 grid gap-4 sm:grid-cols-3">
+          <section className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {t.vibeItems.map((item, idx) => (
-              <article key={item.title} className="rounded-2xl border border-neutral-100 p-5">
+              <article key={item.title} className="rounded-2xl border border-neutral-100 p-5 sm:p-6">
                 <span className="text-sm text-neutral-300">0{idx + 1}</span>
                 <h2 className="mt-2 text-lg font-medium">{item.title}</h2>
                 <p className="mt-2 text-sm leading-relaxed text-neutral-600">{item.text}</p>


### PR DESCRIPTION
### Motivation
- Make the demo video present as a vertical mobile-first experience instead of a wide 16:9 hero to better reflect the product form-factor. 
- Ensure the video remains visually prominent but does not overflow tall viewports on desktop. 
- Improve spacing of the feature/vibe cards beneath the narrower video so the layout feels balanced and uncluttered.

### Description
- Replace the horizontal video container with a centered vertical frame by changing to `aspect-[9/16]`, adding `max-h-[70vh]`, and centering via `mx-auto` in `app/azumbox/page.tsx`.
- Wrap the video in a smartphone-style wrapper using a thin dark border and a soft shadow (`rounded-[2.2rem] border-neutral-800/60 bg-neutral-900 p-1.5 shadow-[0_28px_75px_rgba(24,24,27,0.3)]`) and an inner rounded container for the screen bezel.
- Preserve `autoPlay`, `loop`, `muted`, `playsInline`, `object-cover`, rounded corners, and shadow effects on the `video` element.
- Adjust the vibe/features grid from `sm:grid-cols-3` to `sm:grid-cols-2 lg:grid-cols-3` and increase card padding to `sm:p-6` to reduce crowding beneath the slimmer video.

### Testing
- Ran `npm test`, which exited successfully (project contains no unit tests and prints "No tests yet").
- Ran `npm run build`, which completed successfully and generated static pages and route bundles (build produced non-blocking warnings but finished normally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea99c6e978832ca2ba2d0267b52c26)