### PR TITLE
Skip lowercase redirect for file requests and tidy video JSX

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -315,7 +315,14 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
         <article className="mt-16 overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-xl dark:border-neutral-800 dark:bg-neutral-900">
           <div className="flex flex-col md:flex-row">
             <div className="bg-neutral-100 p-8 md:w-1/3 dark:bg-neutral-800">
-              <video className="mx-auto h-72 rounded-2xl shadow-lg" autoPlay loop muted playsInline preload="metadata">
+              <video
+                className="mx-auto h-72 rounded-2xl shadow-lg"
+                autoPlay
+                loop
+                muted
+                playsInline
+                preload="metadata"
+              >
                 <source src="/WhoopsBirdLines.mp4" type="video/mp4" />
               </video>
               <a

--- a/middleware.ts
+++ b/middleware.ts
@@ -18,7 +18,9 @@ function getPreferredLocale(request: NextRequest): string {
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  if (pathname !== pathname.toLowerCase()) {
+  const isFileRequest = /\/[^/]+\.[^/]+$/.test(pathname);
+
+  if (!isFileRequest && pathname !== pathname.toLowerCase()) {
     return NextResponse.redirect(new URL(pathname.toLowerCase(), request.url), 308);
   }
 


### PR DESCRIPTION
### Motivation
- Avoid unintended 308 redirects for requests that target files (e.g. assets like `WhoopsBirdLines.mp4`) which should not be lowercased. 
- Improve readability of the inlined video element in the landing page JSX.

### Description
- Add `isFileRequest` detection (`/\/[^/]+\.[^/]+$/`) in `middleware.ts` and only perform the pathname lowercase redirect when the request is not a file request. 
- Preserve existing locale redirect and cookie-setting behavior while preventing asset/filename redirects. 
- Reformat the `<video>` element in `app/[locale]/page.tsx` to put attributes on separate lines and keep the `<source>` tag nested inside for improved readability.

### Testing
- Built the app with `next build` to ensure server code and middleware compile successfully and the change does not break the build (succeeded). 
- Ran type checks with `tsc --noEmit` to validate TypeScript types (succeeded). 
- Ran `eslint` across the codebase to verify linting rules (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf220b58c832c9cfd090dd81f5727)