### PR TITLE
Remove video link label under Bird Lines video

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -325,14 +325,6 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
               >
                 <source src="/WhoopsBirdLines.mp4" type="video/mp4" />
               </video>
-              <a
-                href="https://github.com/Azumbo/Azumbo/blob/main/public/WhoopsBirdLines.mp4"
-                target="_blank"
-                rel="noreferrer"
-                className="mt-4 block text-center text-sm font-medium text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
-              >
-                {t.videoLinkLabel}
-              </a>
             </div>
             <div className="p-8 md:w-2/3">
               <h3 className="text-2xl font-bold uppercase tracking-wider">{t.birdTitle}</h3>


### PR DESCRIPTION
### Motivation
- Remove the visible “Open video link” label rendered under the Bird Lines video while leaving the rest of the page intact.

### Description
- Deleted the anchor block that rendered `{t.videoLinkLabel}` and linked to the MP4 in `app/[locale]/page.tsx` so the video no longer shows the external link text.

### Testing
- Ran `npm test`, which executed the package test script and returned "No tests yet" (successful run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd0170028832c942aee5eedeb43d5)