### PR TITLE
Update Azumbox English CTA to donation link

### DIFF
--- a/app/azumbox/page.tsx
+++ b/app/azumbox/page.tsx
@@ -37,7 +37,8 @@ const COPY: Record<Lang, LocalizedCopy> = {
         text: 'A relaxing ritual for commutes, coffee breaks, and elegant procrastination.',
       },
     ],
-    cta: 'Download Azumbox',
+    cta: 'Donate to support',
+    ctaHref: 'https://www.gofundme.com/u/azumbox',
   },
   it: {
     nav: 'Lingua',


### PR DESCRIPTION
### Motivation
- Replace the English CTA on the Azumbox landing to solicit donations and point users to the project's GoFundMe instead of prompting a download.

### Description
- Updated `app/azumbox/page.tsx` to change the English `cta` from `Download Azumbox` to `Donate to support` and added `ctaHref: 'https://www.gofundme.com/u/azumbox'` so the CTA renders as an external link.

### Testing
- Verified the change with `git diff -- app/azumbox/page.tsx` which shows the updated copy and link.
- Confirmed the working tree is clean with `git status --short` after committing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed61bac570832cb1d1c8b99abb79af)