### PR TITLE
Domain-lock middleware, dynamic canonical/hreflang generation, and VideoObject ISO fix

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -160,7 +160,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     description: t.seoDesc,
     alternates: {
       canonical: `${SITE_URL}${canonicalPath}`,
-      languages: buildLanguageAlternates()
+      languages: buildLanguageAlternates(canonicalPath)
     },
     openGraph: {
       title: t.title,
@@ -208,7 +208,7 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
         contentUrl={`${SITE_URL}/WhoopsBirdLines.mp4`}
         embedUrl={`${SITE_URL}/${routeLang}#bird-lines-video`}
         thumbnailUrl={`${SITE_URL}/assets/logo/azumbo-logo.png`}
-        uploadDate="2026-01-15"
+        uploadDate="2026-01-15T00:00:00Z"
         duration="PT45S"
         inLanguage={routeLang}
       />

--- a/app/azumbox/layout.tsx
+++ b/app/azumbox/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { baseMetadata, SITE_URL } from '../../lib/seo';
+
+export const metadata: Metadata = {
+  ...baseMetadata('/azumbox'),
+  title: 'Azumbox — Minimal mobile game by AZUMBO',
+  description:
+    'Azumbox is a polished mobile game concept by AZUMBO with calm pacing, elegant visuals, and smart casual gameplay.',
+  openGraph: {
+    type: 'website',
+    siteName: 'AZUMBO',
+    url: `${SITE_URL}/azumbox`,
+    title: 'Azumbox — Minimal mobile game by AZUMBO',
+    description:
+      'Azumbox is a polished mobile game concept by AZUMBO with calm pacing, elegant visuals, and smart casual gameplay.',
+  },
+};
+
+export default function AzumboxLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -3,35 +3,30 @@ export const SUPPORTED_LOCALES = ['en', 'it', 'ru'] as const;
 
 export type Locale = typeof SUPPORTED_LOCALES[number];
 
-/**
- * Проверяет, поддерживается ли данная локаль
- */
 export function isSupportedLocale(locale: string): locale is Locale {
-  return SUPPORTED_LOCALES.includes(locale as any);
+  return SUPPORTED_LOCALES.includes(locale as Locale);
 }
 
-/**
- * Генерирует ссылки на альтернативные языковые версии страницы
- */
-export function buildLanguageAlternates(path = '') {
-  const cleanPath = path.startsWith('/') ? path : `/${path}`;
-  // Удаляем текущий префикс локали из пути, если он есть
-  const pathWithoutLocale = cleanPath.replace(/^\/(en|it|ru)/, '') || '/';
+export function buildCanonical(pathname = '/') {
+  const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return `${SITE_URL}${normalizedPath}`;
+}
+
+export function buildLanguageAlternates(pathname = '/') {
+  const cleanPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const pathWithoutLocale = cleanPath.replace(/^\/(en|it|ru)(?=\/|$)/, '') || '/';
 
   return {
-    'en-US': `/en${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`,
-    'it-IT': `/it${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`,
-    'ru-RU': `/ru${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`,
+    'en-US': buildCanonical(`/en${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`),
+    'it-IT': buildCanonical(`/it${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`),
+    'ru-RU': buildCanonical(`/ru${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`),
+    'x-default': buildCanonical(`/en${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`),
   };
 }
 
-/**
- * Базовый конфиг метаданных для страниц
- */
-export const baseMetadata = (path: string) => ({
+export const baseMetadata = (pathname: string) => ({
   metadataBase: new URL(SITE_URL),
   alternates: {
-    canonical: path,
-    languages: buildLanguageAlternates(path),
+    canonical: buildCanonical(pathname),
   },
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
+const PRIMARY_HOST = 'azumbo.vercel.app';
 const SUPPORTED_LOCALES = ['en', 'ru', 'it'] as const;
 const DEFAULT_LOCALE = 'en';
 
@@ -11,17 +12,32 @@ function getPreferredLocale(request: NextRequest): string {
   }
 
   const languageHeader = request.headers.get('accept-language')?.toLowerCase() || '';
-  const matched = SUPPORTED_LOCALES.find((locale) => languageHeader.startsWith(locale) || languageHeader.includes(`${locale};`) || languageHeader.includes(`${locale},`));
+  const matched = SUPPORTED_LOCALES.find(
+    (locale) =>
+      languageHeader.startsWith(locale) ||
+      languageHeader.includes(`${locale};`) ||
+      languageHeader.includes(`${locale},`)
+  );
+
   return matched || DEFAULT_LOCALE;
 }
 
 export function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
+  const { pathname, search } = request.nextUrl;
+  const hostname = request.nextUrl.hostname.toLowerCase();
+
+  const isVercelMirror = hostname.endsWith('.vercel.app') && hostname !== PRIMARY_HOST;
+  if (isVercelMirror) {
+    const redirectUrl = `https://${PRIMARY_HOST}${pathname}${search}`;
+    const response = NextResponse.redirect(redirectUrl, 301);
+    response.headers.set('X-Robots-Tag', 'noindex, nofollow');
+    return response;
+  }
 
   const isFileRequest = /\/[^/]+\.[^/]+$/.test(pathname);
 
   if (!isFileRequest && pathname !== pathname.toLowerCase()) {
-    return NextResponse.redirect(new URL(pathname.toLowerCase(), request.url), 308);
+    return NextResponse.redirect(new URL(`${pathname.toLowerCase()}${search}`, request.url), 308);
   }
 
   if (pathname === '/') {

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  trailingSlash: false,
   async redirects() {
     return [
       {


### PR DESCRIPTION
### Motivation
- Google was indexing Vercel preview mirrors and reporting "canonical versions do not match", so requests to technical `*.vercel.app` hosts must be locked to the main site while preserving path and query string. 
- The site needed a single authoritative `SITE_URL` and per-page absolute `rel="canonical"` generation to avoid cross-host canonical drift across locales and single-version project pages. 
- Video schema used a non-ISO `uploadDate` which can invalidate `VideoObject` microdata and must be an ISO 8601 datetime.

### Description
- Added domain-lock logic to `middleware.ts` that detects mirror hosts (`hostname.endsWith('.vercel.app') && hostname !== 'azumbo.vercel.app'`) and issues a `301` redirect to `https://azumbo.vercel.app${pathname}${search}` while adding the `X-Robots-Tag: noindex, nofollow` header, and preserved the existing lowercase + locale cookie logic. 
- Refactored SEO helpers in `lib/seo.ts` by introducing `SITE_URL = 'https://azumbo.vercel.app'`, `buildCanonical(pathname)`, `buildLanguageAlternates(pathname)` that emit absolute hreflang URLs, and `baseMetadata(pathname)` to produce metadata with dynamic canonical values. 
- Updated `app/[locale]/page.tsx` to use the pathname-aware alternates via `buildLanguageAlternates(canonicalPath)` and fixed the `VideoObjectJsonLd` `uploadDate` to the ISO datetime `2026-01-15T00:00:00Z`. 
- Added `app/azumbox/layout.tsx` with `metadata` that uses `baseMetadata('/azumbox')` so that single-version pages get a canonical but no language alternates, and set `trailingSlash: false` in `next.config.js`.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully and compiled middleware and app routes. 
- There are no unit tests in the repo (`npm test` prints "No tests yet"); the changes were validated by a successful production build only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f047e510832c944e2815960ac43a)