### PR TITLE
SEO: streamline middleware for canonical host, locale redirects, and URL normalization

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -26,25 +26,32 @@ export function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
   const hostname = request.nextUrl.hostname.toLowerCase();
 
+  // 1. DOMAIN LOCK: Убираем технические зеркала Vercel
   const isVercelMirror = hostname.endsWith('.vercel.app') && hostname !== PRIMARY_HOST;
   if (isVercelMirror) {
     const redirectUrl = `https://${PRIMARY_HOST}${pathname}${search}`;
     const response = NextResponse.redirect(redirectUrl, 301);
-    response.headers.set('X-Robots-Tag', 'noindex, nofollow');
+    response.headers.set('X-Robots-Tag', 'noindex, nofollow, noarchive');
     return response;
   }
 
+  // 2. СТАТИКА: Пропускаем файлы (изображения, mp4, favicon) без обработки
   const isFileRequest = /\/[^/]+\.[^/]+$/.test(pathname);
+  if (isFileRequest) return NextResponse.next();
 
-  if (!isFileRequest && pathname !== pathname.toLowerCase()) {
+  // 3. НОРМАЛИЗАЦИЯ: Нижний регистр (SEO стандарт)
+  if (pathname !== pathname.toLowerCase()) {
     return NextResponse.redirect(new URL(`${pathname.toLowerCase()}${search}`, request.url), 308);
   }
 
+  // 4. ГЛАВНАЯ: Редирект на язык БЕЗ финального слэша
   if (pathname === '/') {
     const locale = getPreferredLocale(request);
-    return NextResponse.redirect(new URL(`/${locale}/`, request.url), 307);
+    // Исправлено: Редирект на /en (а не /en/), чтобы не конфликтовать с trailingSlash: false
+    return NextResponse.redirect(new URL(`/${locale}${search}`, request.url), 307);
   }
 
+  // 5. КУКИ ЛОКАЛИЗАЦИИ
   const localeMatch = pathname.match(/^\/(en|ru|it)(\/.*)?$/);
   if (localeMatch) {
     const locale = localeMatch[1];
@@ -61,5 +68,6 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|logo|images|site/assets).*)'],
+  // Исключаем API и служебные пути Next.js
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|logo|images|site/assets|.*\\..*).*)'],
 };


### PR DESCRIPTION
### Motivation
- Упростить и ускорить поведение редиректов для краулеров и пользователей за счёт явной каноникализации основного хоста и устранения лишних переходов с/без trailing slash. 
- Снизить нагрузку middleware и риск неверных редиректов на статические ассеты, пропуская файлы сразу. 
- Гарантировать консистентность URL (нижний регистр) и сохранить локаль в куках для корректной локализации.

### Description
- Полная замена логики в `middleware.ts`: жёсткая каноникализация зеркал `*.vercel.app` на `https://azumbo.vercel.app` с `301` и заголовком `X-Robots-Tag: noindex, nofollow, noarchive`.
- Ранний пропуск файловых запросов по регулярному выражению и обновлённый `matcher` в `config` для исключения путей с расширениями (`.*\\..*`).
- Нормализация путей в нижний регистр с возвратом `308` и редирект корня `/` на `/<locale>` (без финального слэша) с сохранением query-string через `getPreferredLocale`.
- Установка куки `azumbo_locale` для путей, начинающихся с `en|ru|it`, и проверка/согласование с `next.config.js` (наличие `trailingSlash: false` и существующая redirect-правило).

### Testing
- Ran `npm run -s lint`, which exited with code 1 because a `lint` script is not defined or the lint command failed. 
- Ran `npm test`, which completed successfully but the project currently reports `No tests yet` (placeholder test script).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9e6030a4832c9bcaa6fa00db267d)