### PR TITLE
Improve SEO governance: central host, AI-bot robots policy, and smoke & live checks

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -4,10 +4,15 @@ import { SITE_URL } from '../lib/seo';
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
-      {
-        userAgent: '*',
-        allow: '/'
-      }
+      { userAgent: '*', allow: '/' },
+      { userAgent: 'Googlebot', allow: '/' },
+      { userAgent: 'Yandex', allow: '/' },
+      { userAgent: 'CCBot', allow: '/' },
+      { userAgent: 'Bytespider', allow: '/' },
+      // GEO policy: allow citation/indexing-oriented bots, disallow model-training crawlers.
+      { userAgent: 'OAI-SearchBot', allow: '/' },
+      { userAgent: 'GPTBot', disallow: '/' },
+      { userAgent: 'Google-Extended', disallow: '/' },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,
     host: SITE_URL

--- a/docs/redirect-registry.md
+++ b/docs/redirect-registry.md
@@ -1,0 +1,7 @@
+# Redirect Registry
+
+| Old URL Pattern | New URL Pattern | Status | Rationale |
+|---|---|---:|---|
+| `https://*.vercel.app/*` (except `azumbo.vercel.app`) | `https://azumbo.vercel.app/*` | 301 | Host canonicalization: remove mirror host duplicates. |
+| `/` | `/{preferred-locale}` (`/en`, `/ru`, `/it`) | 307 | Locale routing based on cookie/Accept-Language. |
+| `/{UPPERCASE_PATH}` | `/{lowercase_path}` | 308 | URL normalization for canonical consistency. |

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,5 +1,7 @@
 export const SITE_URL = 'https://azumbo.vercel.app';
+export const PRIMARY_HOST = 'azumbo.vercel.app';
 export const SUPPORTED_LOCALES = ['en', 'it', 'ru'] as const;
+export const DEFAULT_LOCALE = 'en';
 
 export type Locale = typeof SUPPORTED_LOCALES[number];
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-const PRIMARY_HOST = 'azumbo.vercel.app';
-const SUPPORTED_LOCALES = ['en', 'ru', 'it'] as const;
-const DEFAULT_LOCALE = 'en';
+import { DEFAULT_LOCALE, PRIMARY_HOST, SUPPORTED_LOCALES } from './lib/seo';
 
 function getPreferredLocale(request: NextRequest): string {
   const cookieLocale = request.cookies.get('azumbo_locale')?.value;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "echo \"No tests yet\""
+    "test": "echo \"No tests yet\"",
+    "seo:live": "bash scripts/seo-live-check.sh",
+    "seo:smoke": "node scripts/seo-smoke.mjs"
   },
   "dependencies": {
     "formidable": "^3.5.4",

--- a/scripts/seo-live-check.sh
+++ b/scripts/seo-live-check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE_URL="${1:-https://azumbo.vercel.app}"
+
+urls=("/" "/en" "/ru" "/it" "/sitemap.xml" "/robots.txt")
+
+for p in "${urls[@]}"; do
+  echo "===== $BASE_URL$p ====="
+  curl -sS -I -L "$BASE_URL$p" | awk 'BEGIN{IGNORECASE=1} /HTTP\/|location:|content-type:|x-robots-tag:|link:|cache-control:/'
+  echo
+ done

--- a/scripts/seo-smoke.mjs
+++ b/scripts/seo-smoke.mjs
@@ -1,0 +1,16 @@
+import fs from 'fs';
+
+const sitemapTs = fs.readFileSync('app/sitemap.ts', 'utf8');
+const robotsTs = fs.readFileSync('app/robots.ts', 'utf8');
+const seoTs = fs.readFileSync('lib/seo.ts', 'utf8');
+const localePage = fs.readFileSync('app/[locale]/page.tsx', 'utf8');
+
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+assert(seoTs.includes("SITE_URL = 'https://azumbo.vercel.app'"), 'SITE_URL host mismatch');
+assert(sitemapTs.includes("path === '/' ? '/en' : path"), 'sitemap default locale mapping mismatch');
+assert(!sitemapTs.includes("'/en/'") && !sitemapTs.includes("'/ru/'") && !sitemapTs.includes("'/it/'"), 'sitemap contains trailing slash locale variants');
+assert(robotsTs.includes("userAgent: 'OAI-SearchBot'") && robotsTs.includes("userAgent: 'GPTBot'"), 'AI bot rules missing');
+assert(localePage.includes("languages: buildLanguageAlternates(canonicalPath)"), 'hreflang alternates not wired');
+
+console.log('SEO smoke checks passed');


### PR DESCRIPTION
### Motivation
- Ensure a single primary host and consistent canonical signals across code to avoid mixed canonical/OG/JSON-LD/sitemap values.  
- Control model-training vs citation indexing by adding a segmented AI-bot policy in `robots` to balance visibility and training access.  
- Provide reproducible validation (curl-based live checks and CI smoke checks) to detect regressions in canonical/hreflang/sitemap/robots quickly.

### Description
- Centralized SEO constants in `lib/seo.ts` by adding `PRIMARY_HOST` and `DEFAULT_LOCALE` and reusing `SITE_URL`/locales for canonical and hreflang generation.  
- Updated `middleware.ts` to import `PRIMARY_HOST`, `DEFAULT_LOCALE`, and `SUPPORTED_LOCALES` from `lib/seo.ts` to unify host canonicalization and locale routing.  
- Replaced `app/robots.ts` rules with a segmented AI-bot policy that explicitly allows indexing/citation bots and disallows training-oriented bots (`GPTBot`, `Google-Extended`) while keeping `OAI-SearchBot` allowed.  
- Added reproducible validation and documentation: a curl-based live script `scripts/seo-live-check.sh`, a CI-style smoke script `scripts/seo-smoke.mjs`, a `docs/redirect-registry.md` redirect registry, and npm scripts `seo:live`/`seo:smoke` in `package.json`.

### Testing
- Ran CI smoke checks with `npm run seo:smoke` (this executes `node scripts/seo-smoke.mjs`) and the script completed successfully printing `SEO smoke checks passed`.  
- Executed the live validation `bash scripts/seo-live-check.sh https://azumbo.vercel.app` and observed a `307` redirect from `/` to `/en` and `200 OK` responses for `/en`, `/ru`, `/it`, `/sitemap.xml`, and `/robots.txt`, indicating runtime routing and headers are returning as expected.  
- Marked validations that are fully "validated in code" (centralized `SITE_URL`/`PRIMARY_HOST`, `robots` rules, smoke scripts) and noted that head-level checks for self-canonical and reciprocal hreflang in rendered HTML require live verification against the deployed build ("requires live verification").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda4ab605c832c833a3bc4b28bed7a)