### PR TITLE
SEO: redirect /en/ → /en (308) and centralize VideoObject uploadDate

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import FloatingSprites from '../../components/FloatingSprites';
 import { JsonLd, VideoObjectJsonLd } from '../../components/seo/JsonLd';
-import { SITE_URL, baseMetadata, buildLanguageAlternates, isSupportedLocale } from '../../lib/seo';
+import { SITE_URL, VIDEO_PUBLISH_DATE, baseMetadata, buildLanguageAlternates, isSupportedLocale } from '../../lib/seo';
 
 type Lang = 'en' | 'it' | 'ru';
 
@@ -208,7 +208,7 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
         contentUrl={`${SITE_URL}/WhoopsBirdLines.mp4`}
         embedUrl={`${SITE_URL}/${routeLang}#bird-lines-video`}
         thumbnailUrl={`${SITE_URL}/assets/logo/azumbo-logo.png`}
-        uploadDate="2026-01-15T00:00:00Z"
+        uploadDate={VIDEO_PUBLISH_DATE}
         duration="PT45S"
         inLanguage={routeLang}
       />

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -32,3 +32,5 @@ export const baseMetadata = (pathname: string) => ({
     canonical: buildCanonical(pathname),
   },
 });
+
+export const VIDEO_PUBLISH_DATE = '2026-01-15T00:00:00Z';

--- a/middleware.ts
+++ b/middleware.ts
@@ -49,6 +49,14 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL(`/${locale}${search}`, request.url), 307);
   }
 
+
+  // 4.1 LOCALE TRAILING SLASH: /en/ -> /en (single redirect, preserve query)
+  const localeTrailingSlash = pathname.match(/^\/(en|ru|it)\/$/);
+  if (localeTrailingSlash) {
+    const locale = localeTrailingSlash[1];
+    return NextResponse.redirect(new URL(`/${locale}${search}`, request.url), 308);
+  }
+
   // 5. КУКИ ЛОКАЛИЗАЦИИ
   const localeMatch = pathname.match(/^\/(en|ru|it)(\/.*)?$/);
   if (localeMatch) {


### PR DESCRIPTION
### Motivation
- Убедиться, что локальные корни с финальным слэшем (`/en/`, `/it/`, `/ru/`) canonical-редиректятся на slashless-варинт одним хопом и с сохранением query-параметров. 
- Убрать хардкод даты в JSON-LD `VideoObject` и централизовать значение через константу для более надёжного управления метаданными.

### Description
- Добавлена логика в `middleware.ts`: блок для матча `/^(\/)(en|ru|it)\/$/` который редиректит на `/${locale}${search}` с кодом `308` и сохраняет query-параметры, реализуя единичный canonical-редирект. 
- В `lib/seo.ts` добавлена экспортируемая константа `VIDEO_PUBLISH_DATE = '2026-01-15T00:00:00Z'`. 
- Обновлён `app/[locale]/page.tsx` для импорта `VIDEO_PUBLISH_DATE` и передачи его в `VideoObjectJsonLd` как `uploadDate={VIDEO_PUBLISH_DATE}` вместо хардкода. 
- Существующее поведение редиректа с корня `/` на предпочтительную локаль сохранено (редирект на `/${locale}` с `307`).

### Testing
- Сборка: выполнена команда `npm run build` успешно; сборка прошла с предупреждением про Node модуль в Edge runtime, предупреждение не блокирует билд. 
- Продакшен-стартап: запущен сервер через `npm run start -- --hostname 127.0.0.1 --port 3005` и выполнены HTTP-проверки с `curl`. 
- Проверки редиректов: `curl -I` показал `308` для `/en/` с `Location: /en` и `307` для `/` на `/en`, без циклов; `curl -L` показал `redirects=1` для `/en/`. 
- Проверка query params: `curl -I` и `curl -L` для `/en/?utm=test` и `/en/?utm=test&ref=abc` подтвердили, что параметры полностью сохраняются (`/en?utm=test`, `/en?utm=test&ref=abc`). All checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdde1a0af4832cb6fa918b769e3a0a)