### PR TITLE
Add La Pasta landing, privacy and support pages

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -36,6 +36,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     navGames: 'Games',
     navServices: 'Services',
     navContact: 'Contact',
+    navLaPasta: 'La Pasta',
     servicesTitle: 'Services',
     servicesSubtitle: 'From prototype sprints to publishing and platform ports.',
     srvProtoTitle: 'Prototype Sprint',
@@ -80,6 +81,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     navGames: 'Giochi',
     navServices: 'Servizi',
     navContact: 'Contatto',
+    navLaPasta: 'La Pasta',
     servicesTitle: 'Servizi',
     servicesSubtitle: 'Dallo sprint di prototipo al publishing e porting su console.',
     srvProtoTitle: 'Sprint di Prototipo',
@@ -124,6 +126,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     navGames: 'Игры',
     navServices: 'Услуги',
     navContact: 'Контакты',
+    navLaPasta: 'La Pasta',
     servicesTitle: 'Услуги',
     servicesSubtitle: 'От прототипов до паблишинга и портирования на консоли.',
     srvProtoTitle: 'Прототип-спринт',
@@ -222,6 +225,7 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
             <a href="#games" className="text-neutral-300 hover:text-white transition">{t.navGames}</a>
             <a href="#services" className="text-neutral-300 hover:text-white transition">{t.navServices}</a>
             <a href="#contact" className="text-neutral-300 hover:text-white transition">{t.navContact}</a>
+            <Link href="/lapasta" className="text-neutral-300 hover:text-white transition">{t.navLaPasta}</Link>
           </nav>
 
           {/* Centered Logo */}
@@ -348,9 +352,10 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
         </article>
       </section>
 
-      <footer className="border-t border-neutral-200 py-10 text-center dark:border-neutral-800">
+      <footer id="contact" className="border-t border-neutral-200 py-10 text-center dark:border-neutral-800">
         <p className="text-sm text-neutral-500">{t.footer}</p>
         <p className="mt-2 text-xs text-neutral-400">{t.pressLine}</p>
+        <p className="mt-3 text-xs"><Link href="/lapasta" className="text-neutral-500 underline-offset-4 transition hover:text-neutral-900 hover:underline dark:hover:text-white">La Pasta</Link></p>
       </footer>
     </main>
   );

--- a/app/lapasta/components.tsx
+++ b/app/lapasta/components.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import styles from './lapasta.module.css';
+
+export const APP_STORE_URL = 'https://apps.apple.com/app/id6774466615';
+export const CONTACT_EMAIL = 'azumbogames@gmail.com';
+
+export function LaPastaNav() {
+  return (
+    <header className={styles.nav}>
+      <div className={styles.navInner}>
+        <Link className={styles.brand} href="/lapasta" aria-label="La Pasta home">
+          <span className={styles.brandMark} aria-hidden="true">🍝</span>
+          <span>La Pasta</span>
+        </Link>
+        <nav className={styles.navLinks} aria-label="La Pasta navigation">
+          <Link href="/lapasta">App</Link>
+          <Link href="/lapasta/privacy">Privacy</Link>
+          <Link href="/lapasta/support">Support</Link>
+          <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+export function LaPastaFooter() {
+  return (
+    <footer className={styles.footer}>
+      <div className={`${styles.container} ${styles.footerInner}`}>
+        <p className={styles.sectionText}>© 2026 AZUMBO. La Pasta is crafted for iPhone and iPad.</p>
+        <nav className={styles.footerLinks} aria-label="Footer navigation">
+          <Link href="/lapasta/privacy">Privacy</Link>
+          <Link href="/lapasta/support">Support</Link>
+          <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>
+        </nav>
+      </div>
+    </footer>
+  );
+}
+
+export function AppStoreButton({ compact = false }: { compact?: boolean }) {
+  return (
+    <a className={styles.cta} href={APP_STORE_URL} aria-label="Download La Pasta on the App Store">
+      {compact ? 'App Store' : 'Download on the App Store'}
+    </a>
+  );
+}

--- a/app/lapasta/lapasta.module.css
+++ b/app/lapasta/lapasta.module.css
@@ -1,0 +1,521 @@
+.shell {
+  min-height: 100dvh;
+  color: #1D1D1F;
+  background: linear-gradient(180deg, #FAF8F5 0%, #EFE7DA 100%);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+  overflow-x: hidden;
+}
+
+.shell :global(*) {
+  box-sizing: border-box;
+}
+
+.shell a {
+  color: inherit;
+}
+
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.62);
+  background: rgba(250, 248, 245, 0.78);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.navInner {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 14px 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.brandMark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(230, 95, 75, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(230, 95, 75, 0.18);
+}
+
+.navLinks {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.92rem;
+}
+
+.navLinks a,
+.footerLinks a,
+.textLink {
+  border-radius: 999px;
+  color: #6E6E73;
+  text-decoration: none;
+  transition: color 180ms ease, background 180ms ease, box-shadow 180ms ease;
+}
+
+.navLinks a {
+  padding: 9px 12px;
+}
+
+.navLinks a:hover,
+.footerLinks a:hover,
+.textLink:hover {
+  color: #E65F4B;
+}
+
+.navLinks a:focus-visible,
+.footerLinks a:focus-visible,
+.textLink:focus-visible,
+.cta:focus-visible,
+.secondaryCta:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(230, 95, 75, 0.24), 0 0 0 1px #E65F4B;
+}
+
+.container {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(280px, 0.72fr);
+  gap: 44px;
+  align-items: center;
+  padding: 74px 0 56px;
+}
+
+.hero::before,
+.hero::after,
+.decorBlob {
+  position: absolute;
+  content: '';
+  z-index: 0;
+  border-radius: 999px;
+  filter: blur(2px);
+  pointer-events: none;
+}
+
+.hero::before {
+  right: -92px;
+  top: 84px;
+  width: 220px;
+  height: 220px;
+  background: rgba(216, 183, 106, 0.22);
+}
+
+.hero::after {
+  left: -100px;
+  bottom: 54px;
+  width: 180px;
+  height: 180px;
+  background: rgba(111, 143, 114, 0.16);
+}
+
+.heroCopy,
+.heroCard,
+.section,
+.footer {
+  position: relative;
+  z-index: 1;
+}
+
+.kicker {
+  margin: 0 0 18px;
+  color: #E65F4B;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.title,
+.sectionTitle,
+.cardTitle,
+.legalTitle {
+  font-family: ui-serif, "New York", "Iowan Old Style", Georgia, serif;
+  font-weight: 400;
+  letter-spacing: -0.045em;
+}
+
+.title {
+  margin: 0;
+  max-width: 760px;
+  font-size: clamp(4.7rem, 16vw, 11rem);
+  line-height: 0.82;
+}
+
+.subtitle {
+  max-width: 620px;
+  margin: 28px 0 0;
+  color: #6E6E73;
+  font-size: clamp(1.08rem, 2.4vw, 1.45rem);
+  line-height: 1.58;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  margin-top: 34px;
+}
+
+.cta,
+.secondaryCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  border-radius: 999px;
+  padding: 0 22px;
+  text-decoration: none;
+  font-weight: 700;
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+.cta {
+  color: #fff !important;
+  background: #E65F4B;
+  box-shadow: 0 7px 14px rgba(230, 95, 75, 0.24);
+}
+
+.secondaryCta {
+  color: #1D1D1F !important;
+  background: rgba(255, 255, 255, 0.52);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.72);
+}
+
+.cta:hover,
+.secondaryCta:hover {
+  transform: translateY(-1px);
+}
+
+.heroCard,
+.glassCard,
+.legalCard {
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.55);
+  box-shadow: 0 7px 14px rgba(0, 0, 0, 0.07);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.heroCard {
+  overflow: hidden;
+  border-radius: 34px;
+  padding: 22px;
+}
+
+.phoneMock {
+  min-height: 520px;
+  border-radius: 30px;
+  background:
+    radial-gradient(circle at 50% 18%, rgba(255,255,255,0.88), transparent 28%),
+    linear-gradient(180deg, rgba(250,248,245,0.95), rgba(239,231,218,0.9));
+  box-shadow: inset 0 0 0 1px rgba(29, 29, 31, 0.08);
+  padding: 22px;
+}
+
+.gameTopBar {
+  display: flex;
+  justify-content: space-between;
+  color: #6E6E73;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.timer {
+  color: #E65F4B;
+}
+
+.jarGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin: 36px 0 28px;
+}
+
+.jar {
+  position: relative;
+  display: grid;
+  min-height: 138px;
+  place-items: center;
+  border: 1px solid rgba(255,255,255,0.72);
+  border-radius: 26px 26px 34px 34px;
+  background: linear-gradient(145deg, rgba(255,255,255,0.64), rgba(255,255,255,0.28));
+  box-shadow: inset 8px 8px 22px rgba(255,255,255,0.45), inset -8px -8px 20px rgba(111,143,114,0.08);
+  font-size: 2.4rem;
+}
+
+.jar::before {
+  position: absolute;
+  top: 12px;
+  width: 46px;
+  height: 8px;
+  content: '';
+  border-radius: 999px;
+  background: rgba(216, 183, 106, 0.42);
+}
+
+.choiceGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+
+.choice {
+  border-radius: 16px;
+  padding: 12px 10px;
+  background: rgba(255,255,255,0.56);
+  color: #1D1D1F;
+  font-size: 0.83rem;
+  font-weight: 700;
+  text-align: center;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.7);
+}
+
+.section {
+  padding: 48px 0;
+}
+
+.sectionHeader {
+  max-width: 680px;
+  margin-bottom: 26px;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: clamp(2.2rem, 6vw, 4.5rem);
+  line-height: 0.96;
+}
+
+.sectionText,
+.legalCard p,
+.legalCard li,
+.faqAnswer {
+  color: #6E6E73;
+  line-height: 1.7;
+}
+
+.featuresGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.glassCard,
+.legalCard {
+  border-radius: 22px;
+}
+
+.glassCard {
+  min-height: 206px;
+  padding: 24px;
+}
+
+.featureIcon {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  margin-bottom: 24px;
+  border-radius: 16px;
+  background: rgba(216, 183, 106, 0.18);
+  font-size: 1.45rem;
+}
+
+.cardTitle {
+  margin: 0 0 10px;
+  font-size: 1.55rem;
+}
+
+.downloadPanel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+  border-radius: 28px;
+  padding: 30px;
+  background:
+    radial-gradient(circle at 88% 22%, rgba(230, 95, 75, 0.18), transparent 28%),
+    rgba(255,255,255,0.55);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #6F8F72;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.legalHero {
+  padding: 60px 0 24px;
+}
+
+.legalLayout {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 22px;
+  padding: 20px 0 56px;
+}
+
+.legalAside {
+  align-self: start;
+  padding: 20px;
+}
+
+.legalAside nav {
+  display: grid;
+  gap: 10px;
+}
+
+.legalCard {
+  padding: clamp(22px, 4vw, 42px);
+}
+
+.legalCard section + section,
+.faqList details + details {
+  margin-top: 30px;
+}
+
+.legalTitle {
+  margin: 0 0 16px;
+  font-size: clamp(2.6rem, 10vw, 6rem);
+  line-height: 0.88;
+}
+
+.legalCard h2,
+.legalCard h3 {
+  margin: 0 0 12px;
+  color: #1D1D1F;
+  font-family: ui-serif, "New York", "Iowan Old Style", Georgia, serif;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+}
+
+.legalCard h2 {
+  font-size: clamp(1.7rem, 4.5vw, 2.35rem);
+}
+
+.legalCard h3 {
+  font-size: 1.35rem;
+}
+
+.legalCard ul {
+  margin: 12px 0 0;
+  padding-left: 1.2rem;
+}
+
+.faqList details {
+  border-radius: 20px;
+  background: rgba(255,255,255,0.42);
+  padding: 18px 20px;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.58);
+}
+
+.faqList summary {
+  cursor: pointer;
+  color: #1D1D1F;
+  font-weight: 800;
+}
+
+.faqAnswer {
+  margin: 12px 0 0;
+}
+
+.footer {
+  border-top: 1px solid rgba(255,255,255,0.58);
+  padding: 34px 0 42px;
+}
+
+.footerInner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.footerLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+@media (max-width: 820px) {
+  .navInner,
+  .footerInner,
+  .downloadPanel {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .navLinks {
+    flex-wrap: wrap;
+  }
+
+  .hero,
+  .legalLayout {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    padding-top: 52px;
+  }
+
+  .heroCard {
+    max-width: 430px;
+    margin: 0 auto;
+  }
+
+  .legalAside {
+    display: none;
+  }
+}
+
+@media (max-width: 620px) {
+  .container,
+  .navInner {
+    width: min(100% - 24px, 1120px);
+  }
+
+  .featuresGrid,
+  .choiceGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .phoneMock {
+    min-height: 456px;
+    padding: 18px;
+  }
+
+  .jarGrid {
+    gap: 12px;
+    margin-top: 26px;
+  }
+
+  .jar {
+    min-height: 112px;
+  }
+}

--- a/app/lapasta/page.tsx
+++ b/app/lapasta/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SITE_URL } from '../../lib/seo';
+import { AppStoreButton, LaPastaFooter, LaPastaNav } from './components';
+import styles from './lapasta.module.css';
+
+export const metadata: Metadata = {
+  title: 'La Pasta — 60s Challenge',
+  description: 'A premium 60-second iOS game about Italian pasta shapes. Shuffle glass jars, learn categories, collect pasta, and chase a calmer high score.',
+  alternates: {
+    canonical: `${SITE_URL}/lapasta`,
+  },
+  openGraph: {
+    title: 'La Pasta — 60s Challenge',
+    description: 'A premium 60-second iOS game about Italian pasta shapes, glass jars, collections, daily pasta, and warm Nonna commentary.',
+    url: `${SITE_URL}/lapasta`,
+    siteName: 'AZUMBO',
+    type: 'website',
+  },
+};
+
+const features = [
+  {
+    icon: '🫙',
+    title: 'Glass jars shuffle',
+    text: 'Four translucent jars move with a gentle rhythm. Keep your eye on the pasta, then choose the category before the timer slips away.',
+  },
+  {
+    icon: '🍝',
+    title: 'Collection',
+    text: 'Discover classic and curious shapes as you play. Build a tidy pasta shelf that feels more like a small museum than a score screen.',
+  },
+  {
+    icon: '🇮🇹',
+    title: 'Italian Levels',
+    text: 'Learn families such as corta, lunga, ripiena, pastina, gnocchi, strascinati, and insolita through quick, repeatable rounds.',
+  },
+  {
+    icon: '☀️',
+    title: 'Daily Pasta',
+    text: 'Return for a daily shape, a small ritual, and one more reason to notice the design language of Italian food.',
+  },
+  {
+    icon: '👵',
+    title: 'Nonna commentary',
+    text: 'Warm, light remarks add personality without shouting. Pasta stays the hero; the joke is always served on the side.',
+  },
+];
+
+export default function LaPastaLandingPage() {
+  return (
+    <div className={styles.shell}>
+      <LaPastaNav />
+      <main>
+        <section className={`${styles.container} ${styles.hero}`}>
+          <div className={styles.heroCopy}>
+            <p className={styles.kicker}>iPhone + iPad · iOS 18+</p>
+            <h1 className={styles.title}>La Pasta</h1>
+            <p className={styles.subtitle}>
+              A refined 60-second challenge about Italian pasta shapes. Watch the jars shuffle, name the category, and let pasta be the hero.
+            </p>
+            <div className={styles.actions}>
+              <AppStoreButton />
+              <Link className={styles.secondaryCta} href="/lapasta/support">Read support</Link>
+            </div>
+          </div>
+
+          <div className={styles.heroCard} aria-label="La Pasta game preview">
+            <div className={styles.phoneMock}>
+              <div className={styles.gameTopBar}>
+                <span>La Pasta</span>
+                <span className={styles.timer}>00:42</span>
+              </div>
+              <div className={styles.jarGrid} aria-hidden="true">
+                <span className={styles.jar}>🍝</span>
+                <span className={styles.jar}>〰️</span>
+                <span className={styles.jar}>🥟</span>
+                <span className={styles.jar}>✦</span>
+              </div>
+              <div className={styles.choiceGrid} aria-label="Pasta categories preview">
+                <span className={styles.choice}>corta</span>
+                <span className={styles.choice}>lunga</span>
+                <span className={styles.choice}>ripiena</span>
+                <span className={styles.choice}>pastina</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.container} ${styles.section}`} aria-labelledby="features-title">
+          <div className={styles.sectionHeader}>
+            <p className={styles.kicker}>Fast rounds · slow taste</p>
+            <h2 id="features-title" className={styles.sectionTitle}>A small game with a proper Italian table setting.</h2>
+            <p className={styles.sectionText}>
+              La Pasta keeps the interaction crisp and the mood calm: glass, warmth, restraint, and just enough tomato-red pressure from the timer.
+            </p>
+          </div>
+
+          <div className={styles.featuresGrid}>
+            {features.map((feature) => (
+              <article className={styles.glassCard} key={feature.title}>
+                <span className={styles.featureIcon} aria-hidden="true">{feature.icon}</span>
+                <h3 className={styles.cardTitle}>{feature.title}</h3>
+                <p className={styles.sectionText}>{feature.text}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={`${styles.container} ${styles.section}`} aria-labelledby="download-title">
+          <div className={`${styles.downloadPanel} ${styles.glassCard}`}>
+            <div>
+              <span className={styles.badge}>Remove Ads · €0.99</span>
+              <h2 id="download-title" className={styles.sectionTitle}>Download on the App Store.</h2>
+              <p className={styles.sectionText}>
+                Free to start with optional ad-supported continues. A one-time Remove Ads purchase is available when you want an uninterrupted plate.
+              </p>
+            </div>
+            <AppStoreButton compact />
+          </div>
+        </section>
+      </main>
+      <LaPastaFooter />
+    </div>
+  );
+}

--- a/app/lapasta/privacy/page.tsx
+++ b/app/lapasta/privacy/page.tsx
@@ -1,0 +1,140 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SITE_URL } from '../../../lib/seo';
+import { CONTACT_EMAIL, LaPastaFooter, LaPastaNav } from '../components';
+import styles from '../lapasta.module.css';
+
+export const metadata: Metadata = {
+  title: 'La Pasta Privacy Policy',
+  description: 'Privacy Policy for La Pasta: 60s Challenge, including local progress, advertising, in-app purchases, children’s privacy, data retention, and contact details.',
+  alternates: {
+    canonical: `${SITE_URL}/lapasta/privacy`,
+  },
+  openGraph: {
+    title: 'La Pasta Privacy Policy',
+    description: 'Privacy Policy for La Pasta: 60s Challenge by AZUMBO.',
+    url: `${SITE_URL}/lapasta/privacy`,
+    siteName: 'AZUMBO',
+    type: 'website',
+  },
+};
+
+const sections = [
+  ['collect', 'What we collect'],
+  ['advertising', 'Advertising'],
+  ['iap', 'In-App Purchases'],
+  ['children', 'Children’s privacy'],
+  ['retention', 'Data retention'],
+  ['contact', 'Contact'],
+] as const;
+
+export default function LaPastaPrivacyPage() {
+  return (
+    <div className={styles.shell}>
+      <LaPastaNav />
+      <main>
+        <section className={`${styles.container} ${styles.legalHero}`}>
+          <p className={styles.kicker}>Legal · App Store requirement</p>
+          <h1 className={styles.legalTitle}>Privacy Policy</h1>
+          <p className={styles.subtitle}>For La Pasta: 60s Challenge. Last updated: June 2026.</p>
+        </section>
+
+        <div className={`${styles.container} ${styles.legalLayout}`}>
+          <aside className={`${styles.legalAside} ${styles.glassCard}`} aria-label="Privacy policy sections">
+            <nav>
+              {sections.map(([id, label]) => (
+                <a className={styles.textLink} href={`#${id}`} key={id}>{label}</a>
+              ))}
+            </nav>
+          </aside>
+
+          <article className={styles.legalCard}>
+            <section id="intro" aria-labelledby="intro-title">
+              <h2 id="intro-title">About this policy</h2>
+              <p>
+                This Privacy Policy explains how AZUMBO handles information in La Pasta: 60s Challenge
+                (“La Pasta”, “the app”, “we”, “our”, or “us”). The app is a premium-style pasta category
+                challenge for iPhone and iPad.
+              </p>
+              <p>
+                La Pasta does not require registration, login, or a user account. You can use the app without
+                directly providing your name, email address, or other contact details to us.
+              </p>
+            </section>
+
+            <section id="collect" aria-labelledby="collect-title">
+              <h2 id="collect-title">What we collect</h2>
+              <p>La Pasta is designed to keep gameplay simple and local.</p>
+              <ul>
+                <li>Local game progress may be stored on your device, such as scores, discovered pasta items, settings, and purchase-related app state.</li>
+                <li>We do not create user accounts and we do not ask you to submit profile information inside the app.</li>
+                <li>We do not operate our own analytics or tracking system for La Pasta at this time.</li>
+              </ul>
+            </section>
+
+            <section id="advertising" aria-labelledby="advertising-title">
+              <h2 id="advertising-title">Advertising</h2>
+              <p>
+                La Pasta may show interstitial ads through Google AdMob, including when time expires and a player chooses
+                to continue with an additional 20 seconds. Google AdMob may process device identifiers, approximate device
+                information, ad interaction data, diagnostics, and related advertising data to provide, measure, and improve ads.
+              </p>
+              <p>
+                Google’s handling of advertising data is described in the{' '}
+                <a className={styles.textLink} href="https://policies.google.com/privacy" rel="noopener noreferrer" target="_blank">
+                  Google Privacy Policy
+                </a>
+                . Your device and Apple privacy settings may let you limit ad tracking or reset advertising identifiers.
+              </p>
+            </section>
+
+            <section id="iap" aria-labelledby="iap-title">
+              <h2 id="iap-title">In-App Purchases</h2>
+              <p>
+                La Pasta offers a one-time Remove Ads purchase. In-app purchases are processed by Apple through the App Store.
+                We do not receive your credit card number, bank details, or full payment credentials.
+              </p>
+              <p>
+                Apple may provide purchase status information to the app so that La Pasta can unlock purchased features and
+                restore eligible purchases on your devices.
+              </p>
+            </section>
+
+            <section id="children" aria-labelledby="children-title">
+              <h2 id="children-title">Children’s privacy</h2>
+              <p>
+                La Pasta is not directed at children under 13. We do not knowingly collect personal information from children
+                under 13. If you believe a child has provided personal information to us, please contact us and we will take
+                appropriate steps to delete it where required.
+              </p>
+            </section>
+
+            <section id="retention" aria-labelledby="retention-title">
+              <h2 id="retention-title">Data retention</h2>
+              <p>
+                Local game progress is stored on your device for as long as the app remains installed or until you clear it
+                through available device or app controls. Uninstalling La Pasta removes local app data from the device, subject
+                to normal iOS behavior and any backups or purchase records handled by Apple.
+              </p>
+              <p>
+                Advertising and App Store purchase records may be retained by Google or Apple according to their own policies.
+              </p>
+            </section>
+
+            <section id="contact" aria-labelledby="contact-title">
+              <h2 id="contact-title">Contact</h2>
+              <p>
+                If you have questions about this Privacy Policy or La Pasta, contact us at{' '}
+                <a className={styles.textLink} href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+              </p>
+              <p>
+                For app help, visit <Link className={styles.textLink} href="/lapasta/support">La Pasta Support</Link>.
+              </p>
+            </section>
+          </article>
+        </div>
+      </main>
+      <LaPastaFooter />
+    </div>
+  );
+}

--- a/app/lapasta/support/page.tsx
+++ b/app/lapasta/support/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SITE_URL } from '../../../lib/seo';
+import { CONTACT_EMAIL, LaPastaFooter, LaPastaNav } from '../components';
+import styles from '../lapasta.module.css';
+
+export const metadata: Metadata = {
+  title: 'La Pasta Support',
+  description: 'Support and FAQ for La Pasta: 60s Challenge, including gameplay, continues, Remove Ads, restore purchases, haptics, sound, and progress.',
+  alternates: {
+    canonical: `${SITE_URL}/lapasta/support`,
+  },
+  openGraph: {
+    title: 'La Pasta Support',
+    description: 'Support and FAQ for La Pasta: 60s Challenge by AZUMBO.',
+    url: `${SITE_URL}/lapasta/support`,
+    siteName: 'AZUMBO',
+    type: 'website',
+  },
+};
+
+const faqs = [
+  {
+    question: 'How do I play La Pasta?',
+    answer: 'Each round lasts 60 seconds. Watch the four glass jars shuffle, identify the pasta shown, and choose the correct category: corta, lunga, ripiena, pastina, gnocchi, strascinati, or insolita.',
+  },
+  {
+    question: 'How does the +20 seconds continue work?',
+    answer: 'When time ends, the app may offer a continue. Watching an interstitial ad can add 20 seconds to the current run, so you can keep building your score.',
+  },
+  {
+    question: 'What does Remove Ads include?',
+    answer: 'Remove Ads is a one-time in-app purchase that removes interstitial advertising from La Pasta. The purchase is processed by Apple through the App Store.',
+  },
+  {
+    question: 'How do I restore purchases?',
+    answer: 'Use the Restore Purchases option in the app settings or purchase screen. Make sure you are signed in with the same Apple ID used for the original purchase.',
+  },
+  {
+    question: 'Can I turn off haptics or sound?',
+    answer: 'Yes. La Pasta is designed with calm, tactile feedback. If available in your app version, use the in-app settings to adjust haptics and sound. You can also use iOS system volume and haptic settings.',
+  },
+  {
+    question: 'Why did my progress disappear?',
+    answer: 'Progress is stored locally on your device. Deleting the app, clearing device data, changing devices without a backup, or restoring from an older backup may remove local progress.',
+  },
+  {
+    question: 'Which devices are supported?',
+    answer: 'La Pasta supports iPhone and iPad on iOS 18 or later.',
+  },
+];
+
+export default function LaPastaSupportPage() {
+  return (
+    <div className={styles.shell}>
+      <LaPastaNav />
+      <main>
+        <section className={`${styles.container} ${styles.legalHero}`}>
+          <p className={styles.kicker}>Support · FAQ</p>
+          <h1 className={styles.legalTitle}>How can we help?</h1>
+          <p className={styles.subtitle}>Short answers for La Pasta: 60s Challenge. If something still feels al dente, contact us directly.</p>
+          <div className={styles.actions}>
+            <a className={styles.cta} href={`mailto:${CONTACT_EMAIL}?subject=La%20Pasta%20Support`}>Contact support</a>
+            <Link className={styles.secondaryCta} href="/lapasta/privacy">Privacy Policy</Link>
+          </div>
+        </section>
+
+        <section className={`${styles.container} ${styles.section}`} aria-labelledby="faq-title">
+          <div className={styles.legalCard}>
+            <h2 id="faq-title">Frequently asked questions</h2>
+            <div className={styles.faqList}>
+              {faqs.map((faq) => (
+                <details key={faq.question}>
+                  <summary>{faq.question}</summary>
+                  <p className={styles.faqAnswer}>{faq.answer}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+      <LaPastaFooter />
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 import { SITE_URL, SUPPORTED_LOCALES } from '../lib/seo';
 
-const LAST_MODIFIED = new Date('2026-03-21T00:00:00.000Z');
+const LAST_MODIFIED = new Date('2026-06-12T00:00:00.000Z');
 
 const CORE_ROUTES = [
   '/',
@@ -16,6 +16,9 @@ const CORE_ROUTES = [
   '/register',
   '/stats',
   '/finish',
+  '/lapasta',
+  '/lapasta/privacy',
+  '/lapasta/support',
   '/cityintheplane/privacy',
   '/cornettoclicker/privacy',
   '/cornettoclicker/terms'


### PR DESCRIPTION
### Motivation
- Ship App Store–ready marketing and legal pages for the new iOS app `La Pasta: 60s Challenge` so the product can be linked from the main site and submitted to App Store Connect.
- Provide an English-language Privacy Policy and a Support/FAQ page required by App Store review and to reduce incoming support requests.
- Keep the new pages visually consistent with Azumbo while giving La Pasta a distinct, premium identity for mobile users.

### Description
- Added a static landing page at `app/lapasta/page.tsx` with hero, feature cards, App Store CTA, preview mock and SEO/OpenGraph metadata.
- Implemented Privacy Policy at `app/lapasta/privacy/page.tsx` (English, last updated June 2026) covering local data, AdMob advertising, IAP, children’s privacy, retention and contact email `azumbogames@gmail.com`.
- Implemented Support/FAQ at `app/lapasta/support/page.tsx` with 7 FAQs and a `mailto:` contact CTA and link to the privacy page.
- Added shared La Pasta components and styles in `app/lapasta/components.tsx` and `app/lapasta/lapasta.module.css` implementing the Liquid Glass look, color system and typography rules.
- Integrated the app into the main site by adding a `La Pasta` link in the main nav/footer (`app/[locale]/page.tsx`) and added the routes to the sitemap in `app/sitemap.ts`.

### Testing
- Ran a production build with `npm run build` and the build completed successfully with the new routes included in the generated route list.
- Ran `npm test` which returned the repo test stub output (`No tests yet`).
- Started the app and performed smoke checks with `curl` against `/lapasta`, `/lapasta/privacy`, and `/lapasta/support`, all returning HTTP `200`.
- Verified `sitemap` updated with the new routes and `robots` remained unchanged by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c5a75b9e0832c8de6d013d4cfdee4)