### PR TITLE
Normalize contact emails to azumbogames@gmail.com

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -57,7 +57,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     videoLinkLabel: 'Open video link',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
-    pressLine: 'For publishers & press: AzumboGames@gmail.com',
+    pressLine: 'For publishers & press: azumbogames@gmail.com',
     ciroPrivacy: 'Ciro.Map Privacy'
   },
   it: {
@@ -103,7 +103,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     videoLinkLabel: 'Apri link video',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
-    pressLine: 'Per editori e stampa: AzumboGames@gmail.com',
+    pressLine: 'Per editori e stampa: azumbogames@gmail.com',
     ciroPrivacy: 'Privacy Ciro.Map'
   },
   ru: {
@@ -149,7 +149,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     videoLinkLabel: 'Открыть ссылку на видео',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
-    pressLine: 'Для издателей и прессы: AzumboGames@gmail.com',
+    pressLine: 'Для издателей и прессы: azumbogames@gmail.com',
     ciroPrivacy: 'Конфиденциальность Ciro.Map'
   }
 };

--- a/app/ciromap/page.tsx
+++ b/app/ciromap/page.tsx
@@ -44,7 +44,7 @@ export default function CiroMapLandingPage() {
           <nav className={styles.nav} aria-label="Ciro.Map navigation">
             <Link href="/en">Azumbo</Link>
             <Link href="/ciromap/privacy">Privacy Policy</Link>
-            <a href="mailto:privacy@azumbo.com">Contact</a>
+            <a href="mailto:azumbogames@gmail.com">Contact</a>
           </nav>
         </div>
       </header>

--- a/app/ciromap/privacy/PrivacyClient.tsx
+++ b/app/ciromap/privacy/PrivacyClient.tsx
@@ -6,7 +6,7 @@ import styles from '../ciromap.module.css';
 
 type Lang = 'en' | 'it' | 'ru';
 const LANGS: Lang[] = ['en', 'it', 'ru'];
-const CONTACT_EMAIL = 'privacy@azumbo.com';
+const CONTACT_EMAIL = 'azumbogames@gmail.com';
 
 const copy = {
   en: {


### PR DESCRIPTION
### Motivation
- Ensure the public contact address is consistent and correct by replacing legacy or inconsistent addresses like `privacy@azumbo.com` and capitalized variants with the canonical `azumbogames@gmail.com`.
- Prevent user confusion and broken mailto links across the site copy and Ciro.Map privacy pages.

### Description
- Replaced press contact casing and normalized publisher/press lines to `azumbogames@gmail.com` in `app/[locale]/page.tsx` for `en`, `it`, and `ru` locales.
- Replaced the Ciro.Map privacy contact link in `app/ciromap/page.tsx` to `mailto:azumbogames@gmail.com`.
- Updated the Ciro.Map privacy client constant `CONTACT_EMAIL` to `azumbogames@gmail.com` in `app/ciromap/privacy/PrivacyClient.tsx`.

### Testing
- Ran a repository email regex search with `rg` to locate addresses and confirm replacements, which showed the updated occurrences; this check succeeded.
- Ran `npm test` (project prints `No tests yet`) which completed successfully.
- Ran TypeScript verification with `npx tsc --noEmit` which completed with no type errors.
- Ran `git diff --check` to validate whitespace/merge issues and committed the changes as `Update site contact emails`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a380ab06980832c9048bf287708abea)