### PR TITLE
Update public/ads.txt with Google publisher entry

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,4 +1,1 @@
-# Placeholder — replace before production.
-# If using ironSource LevelPlay mediation: copy the aggregated ads.txt from the LevelPlay Ads.txt Manager.
-# If using AdMob directly (example):
-# google.com, pub-XXXXXXXXXXXXXXXX, DIRECT, f08c47fec0942fa0
+google.com, pub-2475393065586904, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
### Motivation
- Replace the placeholder `public/ads.txt` with the requested Google publisher entry so the site advertises the correct authorized seller for production.

### Description
- Replace `public/ads.txt` contents with the single line `google.com, pub-2475393065586904, DIRECT, f08c47fec0942fa0` and leave `public/app-ads.txt` unchanged; an attempt to deploy with `npx vercel --prod --yes` was performed but could not complete due to an invalid Vercel token and network error.

### Testing
- Ran `npm test` which exited successfully, and ran `npm run build` which completed successfully (the build emitted warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39925c0b20832cb81283baf4be75ff)