### PR TITLE
fix(seo): dedupe sitemap routes without Set spread for es5 target

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -23,7 +23,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     };
   });
 
-  const staticPaths = [...new Set([...INDEXABLE_ROUTES, ...getPublicAppRoutes()])];
+  const mergedRoutes = [...INDEXABLE_ROUTES, ...getPublicAppRoutes()];
+  const staticPaths = mergedRoutes.filter(
+    (path, index) => mergedRoutes.indexOf(path) === index
+  );
 
   const staticRoutes = staticPaths.map((path) => ({
     url: `${SITE_URL}${path}`,


### PR DESCRIPTION
Replace Set spread with indexOf filtering so Next.js typecheck passes under tsconfig target es5.