### PR TITLE
fix(ui): shorten EN homepage title and prevent Space Invaders logo ov…

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -15,7 +15,7 @@ const isLang = (value: string): value is Lang => isSupportedLocale(value);
 
 const STRINGS: Record<Lang, Record<string, string>> = {
   en: {
-    title: 'AZUMBO | Indie Mobile Game Studio USA',
+    title: 'AZUMBO | Indie Mobile Game Studio',
     seoDesc:
       'US indie studio building mobile and Nintendo Switch games. Prototype sprints, publishing, UA support, and platform ports for Android and iOS.',
     kicker: 'Mobile-first games with humor & heart.',

--- a/app/spaceinvaders/page.tsx
+++ b/app/spaceinvaders/page.tsx
@@ -258,28 +258,30 @@ export default function SpaceInvaders() {
   }, [status, gameKey]);
 
   return (
-    <div className="pixel-container">
+    <div className="flex min-h-[100dvh] flex-col items-center px-4 py-3">
       <SoftwareApplicationJsonLd
         name="AZUMBO Space Invaders"
         description="Defend Earth from invading aliens in a polished browser version of the arcade classic."
         url="https://azumbo.vercel.app/spaceinvaders"
         image="https://azumbo.vercel.app/assets/logo/azumbo-icon.png"
       />
-      <Link
-        href="https://azumbo.vercel.app/en"
-        className="fixed left-2 top-2 z-50 rounded-md bg-white/85 p-0.5 shadow"
-        aria-label="Go to AZUMBO home"
-      >
-        <Image
-          src="/logo/Azumbo Logo no background Sm.png"
-          alt="AZUMBO"
-          width={120}
-          height={44}
-          priority
-          className="h-auto w-[64px] sm:w-[78px]"
-        />
-      </Link>
-      <h1>👾 Space Invaders</h1>
+      <header className="mb-4 flex w-full max-w-lg items-center gap-3">
+        <Link
+          href="https://azumbo.vercel.app/en"
+          className="shrink-0 rounded-md bg-white/85 p-0.5 shadow"
+          aria-label="Go to AZUMBO home"
+        >
+          <Image
+            src="/logo/Azumbo Logo no background Sm.png"
+            alt="AZUMBO"
+            width={120}
+            height={44}
+            priority
+            className="h-auto w-[64px] sm:w-[78px]"
+          />
+        </Link>
+        <h1 className="text-lg font-bold sm:text-xl">👾 Space Invaders</h1>
+      </header>
       {status === 'play' && (
         <canvas
           ref={canvasRef}
@@ -288,7 +290,7 @@ export default function SpaceInvaders() {
       )}
       <a
         href="mailto:azumbogames@gmail.com?subject=Game%20Development%20Inquiry"
-        className="mt-4 inline-block rounded-md border border-black px-4 py-2 text-center text-sm font-semibold"
+        className="mt-4 inline-block max-w-lg rounded-md border border-black px-4 py-2 text-center text-sm font-semibold"
       >
         {ctaText}
       </a>


### PR DESCRIPTION
…erlap

Remove USA from the English studio title and move the arcade page logo into a header row so it no longer covers the CTA text.