### PR TITLE
fix(audio): Apple-style sound UX and unified mute control

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -321,6 +321,7 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
                 muted
                 playsInline
                 preload="metadata"
+                data-force-muted
                 aria-label="Bird Lines game preview video"
               >
                 <source src="/WhoopsBirdLines.mp4" type="video/mp4" />

--- a/app/frogger/page.tsx
+++ b/app/frogger/page.tsx
@@ -12,6 +12,7 @@ import {
   playBackgroundMusic,
   stopBackgroundMusic,
   froggerTheme,
+  unlockAudio,
 } from '../../lib/froggerAudio';
 
 export default function FroggerPage() {
@@ -30,15 +31,16 @@ export default function FroggerPage() {
   }, []);
 
   useEffect(() => {
-    if (status === 'play') {
-      playBackgroundMusic(froggerTheme);
-    } else {
+    if (status !== 'play') {
       stopBackgroundMusic();
     }
+  }, [status]);
+
+  useEffect(() => {
     return () => {
       stopBackgroundMusic();
     };
-  }, [status]);
+  }, []);
 
   useEffect(() => {
     initAudioSystem();
@@ -68,8 +70,13 @@ export default function FroggerPage() {
     const houses = [1, 4, 7];
 
     const keys: Record<string, boolean> = {};
+    let musicStarted = false;
     const keydown = (e: KeyboardEvent) => {
       keys[e.key] = true;
+      if (!musicStarted && status === 'play') {
+        musicStarted = true;
+        void unlockAudio().then(() => playBackgroundMusic(froggerTheme));
+      }
     };
     const keyup = (e: KeyboardEvent) => {
       keys[e.key] = false;

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { playJumpSound, playAmbientLoop, stopAmbientLoop } from '../../lib/audioManager';
+import { playJumpSound } from '../../lib/audioManager';
+import { unlockAudio } from '../../lib/froggerAudio';
 
 export default function GamePage() {
   const router = useRouter();
@@ -10,7 +11,6 @@ export default function GamePage() {
 
   useEffect(() => {
     if (level > 10) {
-      stopAmbientLoop();
       const code = localStorage.getItem('playerCode') || '';
       fetch('/api/submit-score', {
         method: 'POST',
@@ -22,15 +22,8 @@ export default function GamePage() {
     }
   }, [level, router, score]);
 
-  useEffect(() => {
-    playAmbientLoop();
-    return () => {
-      stopAmbientLoop();
-    };
-  }, []);
-
   const nextLevel = () => {
-    playJumpSound();
+    void unlockAudio().then(() => playJumpSound());
     setScore((s) => s + 10);
     setLevel((l) => l + 1);
   };

--- a/app/pacman/page.tsx
+++ b/app/pacman/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { pacmanAudio } from '../../lib/pacmanAudio';
+import { unlockAudio } from '../../lib/froggerAudio';
 import styles from './PacMan.module.css';
 import { SoftwareApplicationJsonLd } from '../../components/seo/JsonLd';
 
@@ -138,6 +139,7 @@ export default function PacManPage() {
 
     const keydown = (e: KeyboardEvent) => {
       if (['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'].includes(e.key)) {
+        void unlockAudio();
         startMove(e.key as any);
       }
     };

--- a/app/spaceinvaders/page.tsx
+++ b/app/spaceinvaders/page.tsx
@@ -3,63 +3,18 @@ import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { SoftwareApplicationJsonLd } from '../../components/seo/JsonLd';
-
-const audioCtx = typeof window !== 'undefined' ? new (window.AudioContext || (window as any).webkitAudioContext)() : null;
-
-function playSound(freq: number, type: OscillatorType, attack = 0.05, release = 0.1) {
-  if (!audioCtx) return;
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-  osc.type = type;
-  osc.frequency.value = freq;
-  osc.connect(gain);
-  gain.connect(audioCtx.destination);
-  gain.gain.setValueAtTime(0, audioCtx.currentTime);
-  gain.gain.linearRampToValueAtTime(0.3, audioCtx.currentTime + attack);
-  gain.gain.exponentialRampToValueAtTime(0.01, audioCtx.currentTime + attack + release);
-  osc.start();
-  osc.stop(audioCtx.currentTime + attack + release);
-}
-
-function createNoise(ctx: AudioContext) {
-  const bufferSize = ctx.sampleRate * 0.2;
-  const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
-  const data = buffer.getChannelData(0);
-  for (let i = 0; i < bufferSize; i++) data[i] = Math.random() * 2 - 1;
-  const noise = ctx.createBufferSource();
-  noise.buffer = buffer;
-  noise.loop = true;
-  noise.start();
-  return noise;
-}
-
-function playLaser(freq: number, dur: number) {
-  if (!audioCtx) return;
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-  osc.type = 'sawtooth';
-  osc.frequency.value = freq;
-  osc.frequency.exponentialRampToValueAtTime(0.01, audioCtx.currentTime + dur);
-  osc.connect(gain);
-  gain.connect(audioCtx.destination);
-  gain.gain.setValueAtTime(0.3, audioCtx.currentTime);
-  gain.gain.exponentialRampToValueAtTime(0.01, audioCtx.currentTime + dur);
-  osc.start();
-  osc.stop(audioCtx.currentTime + dur);
-}
+import {
+  createExplosionNoise,
+  initAudioSystem,
+  playLaserSound,
+  playSound,
+  unlockAudio,
+} from '../../lib/froggerAudio';
 
 const invadersAudio = {
-  playerShot: () => playLaser(600, 0.1),
-  invaderShot: () => playLaser(300, 0.1),
-  explosion: () => {
-    if (!audioCtx) return;
-    const noise = createNoise(audioCtx);
-    const filter = audioCtx.createBiquadFilter();
-    filter.type = 'bandpass';
-    filter.frequency.value = 800;
-    noise.connect(filter).connect(audioCtx.destination);
-    setTimeout(() => noise.stop(), 200);
-  },
+  playerShot: () => playLaserSound(600, 0.1),
+  invaderShot: () => playLaserSound(300, 0.1),
+  explosion: () => createExplosionNoise(),
   move: (step: number) => playSound(100 + step * 50, 'square', 0.05, 0.1),
 };
 
@@ -85,6 +40,7 @@ export default function SpaceInvaders() {
   };
 
   useEffect(() => {
+    initAudioSystem();
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
@@ -117,6 +73,7 @@ export default function SpaceInvaders() {
     const keys: Record<string, boolean> = {};
 
     const keydown = (e: KeyboardEvent) => {
+      void unlockAudio();
       keys[e.key] = true;
     };
     const keyup = (e: KeyboardEvent) => {

--- a/components/GameFX.tsx
+++ b/components/GameFX.tsx
@@ -1,36 +1,30 @@
 'use client';
+
 import { useEffect } from 'react';
 import SoundToggle from './SoundToggle';
-import { playAmbientLoop, playClickSound, playHoverSound, mute, unmute } from '../lib/audioManager';
+import { initAudioPreferences, unlockAudio } from '../lib/audioManager';
 
 export default function GameFX() {
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const muted = localStorage.getItem('muted') === 'true';
-      muted ? mute() : unmute();
-    }
-    playAmbientLoop();
-    const handleClick = (e: MouseEvent) => {
-      playClickSound();
+    initAudioPreferences();
+
+    const handlePointerDown = () => {
+      void unlockAudio();
     };
-    const handleHover = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.closest('a, button, .clickable')) {
-        playHoverSound();
-      }
-    };
+
     const handleDown = () => document.body.classList.add('cursor-click');
     const handleUp = () => document.body.classList.remove('cursor-click');
-    document.addEventListener('click', handleClick);
-    document.addEventListener('mouseover', handleHover);
+
+    document.addEventListener('pointerdown', handlePointerDown, { passive: true });
     document.addEventListener('mousedown', handleDown);
     document.addEventListener('mouseup', handleUp);
+
     return () => {
-      document.removeEventListener('click', handleClick);
-      document.removeEventListener('mouseover', handleHover);
+      document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('mousedown', handleDown);
       document.removeEventListener('mouseup', handleUp);
     };
   }, []);
+
   return <SoundToggle />;
 }

--- a/components/SoundToggle.tsx
+++ b/components/SoundToggle.tsx
@@ -1,26 +1,26 @@
 'use client';
-import { useState, useEffect } from 'react';
-import { toggleMute } from '../lib/audioManager';
+
+import { useEffect, useState } from 'react';
+import { isAudioMuted, subscribeMuteState, toggleMute } from '../lib/audioManager';
 
 export default function SoundToggle() {
-  const [muted, setMuted] = useState(false);
+  const [muted, setMuted] = useState(true);
 
-  useEffect(() => {
-    setMuted(localStorage.getItem('muted') === 'true');
-  }, []);
+  useEffect(() => subscribeMuteState(setMuted), []);
 
   const handleClick = () => {
-    toggleMute();
-    const newMuted = !muted;
-    setMuted(newMuted);
-    localStorage.setItem('muted', newMuted ? 'true' : 'false');
+    void toggleMute();
   };
 
   return (
     <button
+      type="button"
       className="pixel-button pressable"
       onClick={handleClick}
-      style={{ position: 'fixed', top: 10, right: 10 }}
+      aria-label={muted ? 'Turn sound on' : 'Turn sound off'}
+      aria-pressed={!muted}
+      title={muted ? 'Sound off' : 'Sound on'}
+      style={{ position: 'fixed', top: 10, right: 10, zIndex: 50 }}
     >
       {muted ? '🔇' : '🔊'}
     </button>

--- a/components/SoundToggle.tsx
+++ b/components/SoundToggle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { isAudioMuted, subscribeMuteState, toggleMute } from '../lib/audioManager';
+import { subscribeMuteState, toggleMute } from '../lib/audioManager';
 
 export default function SoundToggle() {
   const [muted, setMuted] = useState(true);

--- a/lib/audioManager.ts
+++ b/lib/audioManager.ts
@@ -1,16 +1,28 @@
 const MUTE_STORAGE_KEY = 'azumbo:audio-muted';
+const LEGACY_MUTE_STORAGE_KEY = 'muted';
 
-let ambient: HTMLAudioElement | null = null;
-let jumpSound: HTMLAudioElement | null = null;
 let audioCtx: AudioContext | null = null;
 let masterGain: GainNode | null = null;
-let isMuted = false;
+let isMuted = true;
+let isUnlocked = false;
 
 const mediaVolumeCache = new WeakMap<HTMLMediaElement, number>();
+const muteListeners = new Set<(muted: boolean) => void>();
+
+function migrateLegacyMuteKey() {
+  if (typeof window === 'undefined') return;
+  const legacy = window.localStorage.getItem(LEGACY_MUTE_STORAGE_KEY);
+  if (legacy === null) return;
+  window.localStorage.setItem(MUTE_STORAGE_KEY, legacy === 'true' ? '1' : '0');
+  window.localStorage.removeItem(LEGACY_MUTE_STORAGE_KEY);
+}
 
 function readMuteState() {
-  if (typeof window === 'undefined') return false;
-  return window.localStorage.getItem(MUTE_STORAGE_KEY) === '1';
+  if (typeof window === 'undefined') return true;
+  migrateLegacyMuteKey();
+  const stored = window.localStorage.getItem(MUTE_STORAGE_KEY);
+  if (stored === null) return true;
+  return stored === '1';
 }
 
 function persistMuteState(value: boolean) {
@@ -18,7 +30,29 @@ function persistMuteState(value: boolean) {
   window.localStorage.setItem(MUTE_STORAGE_KEY, value ? '1' : '0');
 }
 
-function ensureMasterGain(ctx: AudioContext) {
+function notifyMuteListeners() {
+  muteListeners.forEach((listener) => listener(isMuted));
+}
+
+export function subscribeMuteState(listener: (muted: boolean) => void) {
+  muteListeners.add(listener);
+  listener(isMuted);
+  return () => muteListeners.delete(listener);
+}
+
+export function getSharedAudioContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null;
+  if (!audioCtx) {
+    const Ctx = window.AudioContext || (window as Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctx) return null;
+    audioCtx = new Ctx();
+  }
+  return audioCtx;
+}
+
+export function getSharedMasterGain(): GainNode | null {
+  const ctx = getSharedAudioContext();
+  if (!ctx) return null;
   if (!masterGain) {
     masterGain = ctx.createGain();
     masterGain.gain.value = isMuted ? 0 : 1;
@@ -34,12 +68,11 @@ function syncMediaElements() {
     if (!mediaVolumeCache.has(element)) {
       mediaVolumeCache.set(element, element.volume || 1);
     }
-
     if (isMuted) {
       element.muted = true;
       element.volume = 0;
     } else {
-      element.muted = false;
+      element.muted = element.hasAttribute('data-force-muted');
       element.volume = mediaVolumeCache.get(element) ?? 1;
     }
   });
@@ -47,86 +80,81 @@ function syncMediaElements() {
 
 export function initAudioPreferences() {
   isMuted = readMuteState();
+  getSharedMasterGain();
   syncMediaElements();
 }
 
-export function playAmbientLoop() {
-  if (isMuted) return;
-  if (!ambient) {
-    ambient = new Audio('/assets/ambient.mp3');
-    ambient.loop = true;
+export function isAudioUnlocked() {
+  return isUnlocked;
+}
+
+export async function unlockAudio() {
+  if (typeof window === 'undefined') return;
+  const ctx = getSharedAudioContext();
+  if (!ctx) return;
+  if (ctx.state === 'suspended') {
+    await ctx.resume();
   }
-  ambient.currentTime = 0;
-  ambient.play();
+  isUnlocked = true;
 }
 
-export function stopAmbientLoop() {
-  ambient?.pause();
+export function canPlayAudio() {
+  return isUnlocked && !isMuted;
 }
 
-export function playJumpSound() {
-  if (isMuted) return;
-  if (!jumpSound) {
-    jumpSound = new Audio('/assets/jump.mp3');
-  }
-  jumpSound.currentTime = 0;
-  jumpSound.play();
-}
+function beep(freq: number, duration = 0.1, volume = 0.08) {
+  if (!canPlayAudio()) return;
+  const ctx = getSharedAudioContext();
+  const output = getSharedMasterGain();
+  if (!ctx || !output) return;
 
-function getCtx() {
-  if (!audioCtx) {
-    audioCtx = new (window.AudioContext || (window as Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext)();
-  }
-  return audioCtx;
-}
-
-function beep(freq: number, duration = 0.1) {
-  if (isMuted) return;
-  const ctx = getCtx();
-  const output = ensureMasterGain(ctx);
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
-
   osc.type = 'square';
   osc.frequency.value = freq;
   osc.connect(gain);
   gain.connect(output);
-
   osc.start();
-  gain.gain.setValueAtTime(0.1, ctx.currentTime);
+  gain.gain.setValueAtTime(volume, ctx.currentTime);
   gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
   osc.stop(ctx.currentTime + duration);
 }
 
-export function playClickSound() {
-  beep(220, 0.07);
+export function playJumpSound() {
+  beep(523.25, 0.1, 0.12);
 }
 
-export function playHoverSound() {
-  beep(440, 0.05);
+export function playClickSound() {
+  beep(220, 0.07, 0.06);
 }
 
 export function mute() {
   isMuted = true;
-  if (masterGain) {
-    masterGain.gain.setValueAtTime(0, getCtx().currentTime);
+  const gain = getSharedMasterGain();
+  const ctx = getSharedAudioContext();
+  if (gain && ctx) {
+    gain.gain.setValueAtTime(0, ctx.currentTime);
   }
-  ambient?.pause();
   syncMediaElements();
   persistMuteState(true);
+  notifyMuteListeners();
 }
 
 export function unmute() {
   isMuted = false;
-  if (masterGain) {
-    masterGain.gain.setValueAtTime(1, getCtx().currentTime);
+  const gain = getSharedMasterGain();
+  const ctx = getSharedAudioContext();
+  if (gain && ctx) {
+    gain.gain.setValueAtTime(1, ctx.currentTime);
   }
   syncMediaElements();
   persistMuteState(false);
+  notifyMuteListeners();
 }
 
-export function toggleMute() {
+export async function toggleMute() {
   if (isMuted) {
+    await unlockAudio();
     unmute();
   } else {
     mute();
@@ -138,4 +166,6 @@ export function isAudioMuted() {
   return isMuted;
 }
 
-initAudioPreferences();
+if (typeof window !== 'undefined') {
+  initAudioPreferences();
+}

--- a/lib/audioManager.ts
+++ b/lib/audioManager.ts
@@ -37,7 +37,9 @@ function notifyMuteListeners() {
 export function subscribeMuteState(listener: (muted: boolean) => void) {
   muteListeners.add(listener);
   listener(isMuted);
-  return () => muteListeners.delete(listener);
+  return () => {
+    muteListeners.delete(listener);
+  };
 }
 
 export function getSharedAudioContext(): AudioContext | null {

--- a/lib/froggerAudio.ts
+++ b/lib/froggerAudio.ts
@@ -1,60 +1,44 @@
+import {
+  canPlayAudio,
+  getSharedAudioContext,
+  getSharedMasterGain,
+  unlockAudio,
+} from './audioManager';
+
 export type OscType = OscillatorType;
 
-const MUTE_STORAGE_KEY = 'azumbo:audio-muted';
-
-let audioCtx: AudioContext | null = null;
-let masterGain: GainNode | null = null;
-
-function isMuted() {
-  if (typeof window === 'undefined') return false;
-  return window.localStorage.getItem(MUTE_STORAGE_KEY) === '1';
-}
-
-function getCtx(): AudioContext {
-  if (!audioCtx) {
-    audioCtx = new (window.AudioContext || (window as Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext)();
-  }
-  return audioCtx;
-}
-
-function getMasterGain() {
-  const ctx = getCtx();
-  if (!masterGain) {
-    masterGain = ctx.createGain();
-    masterGain.connect(ctx.destination);
-  }
-  masterGain.gain.value = isMuted() ? 0 : 1;
-  return masterGain;
-}
+export { unlockAudio };
 
 export function initAudioSystem() {
-  getCtx();
-  getMasterGain();
+  getSharedMasterGain();
 }
 
 export function playSound(freq: number, type: OscType, duration = 0.2, volume = 0.2) {
-  if (isMuted()) return;
+  if (!canPlayAudio()) return;
 
-  const ctx = getCtx();
+  const ctx = getSharedAudioContext();
+  const output = getSharedMasterGain();
+  if (!ctx || !output) return;
+
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
-
   osc.type = type;
   osc.frequency.value = freq;
   gain.gain.setValueAtTime(volume, ctx.currentTime);
   gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
-
   osc.connect(gain);
-  gain.connect(getMasterGain());
-
+  gain.connect(output);
   osc.start();
   osc.stop(ctx.currentTime + duration);
 }
 
 export function createExplosionNoise(duration = 0.3) {
-  if (isMuted()) return;
+  if (!canPlayAudio()) return;
 
-  const ctx = getCtx();
+  const ctx = getSharedAudioContext();
+  const output = getSharedMasterGain();
+  if (!ctx || !output) return;
+
   const bufferSize = ctx.sampleRate * duration;
   const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
   const data = buffer.getChannelData(0);
@@ -66,8 +50,28 @@ export function createExplosionNoise(duration = 0.3) {
   filter.type = 'highpass';
   filter.frequency.value = 500;
   source.buffer = buffer;
-  source.connect(filter).connect(getMasterGain());
+  source.connect(filter).connect(output);
   source.start();
+}
+
+export function playLaserSound(startFreq: number, duration: number) {
+  if (!canPlayAudio()) return;
+
+  const ctx = getSharedAudioContext();
+  const output = getSharedMasterGain();
+  if (!ctx || !output) return;
+
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'sawtooth';
+  osc.frequency.value = startFreq;
+  osc.frequency.exponentialRampToValueAtTime(0.01, ctx.currentTime + duration);
+  osc.connect(gain);
+  gain.connect(output);
+  gain.gain.setValueAtTime(0.25, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + duration);
+  osc.start();
+  osc.stop(ctx.currentTime + duration);
 }
 
 export function playJumpSound() {
@@ -95,13 +99,17 @@ let musicOsc: OscillatorNode | null = null;
 let musicPlaying = false;
 
 export function playBackgroundMusic(notes: Note[], tempo = 180) {
-  if (isMuted()) return;
+  if (!canPlayAudio()) return;
 
-  const ctx = getCtx();
+  const ctx = getSharedAudioContext();
+  const output = getSharedMasterGain();
+  if (!ctx || !output) return;
+
   musicPlaying = true;
 
   const schedule = () => {
-    if (!musicPlaying || isMuted()) return;
+    if (!musicPlaying || !canPlayAudio()) return;
+
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
     osc.type = 'triangle';
@@ -113,7 +121,7 @@ export function playBackgroundMusic(notes: Note[], tempo = 180) {
       time += (60 / tempo) * (n.dur || 1);
     });
 
-    osc.connect(gain).connect(getMasterGain());
+    osc.connect(gain).connect(output);
     osc.start();
     osc.stop(time);
     musicOsc = osc;


### PR DESCRIPTION
## Summary
- Unify site audio under a single `AudioContext` and one mute key (`azumbo:audio-muted`), with legacy key migration
- Default to muted on load; unlock playback only after explicit user gesture (tap/keydown)
- Remove autoplay ambient loop and hover/click sounds on global links
- Route Frogger, Space Invaders, Pac-Man, and arcade pages through shared mute-aware SFX
- Sync `SoundToggle` with mute state via subscription; improve accessibility labels

## Test plan
- [ ] Open homepage on Safari/iOS — no sound until user taps and toggles sound on
- [ ] Toggle sound button — mute state persists across reload
- [ ] Play Frogger / Space Invaders / Pac-Man — SFX respect mute toggle
- [ ] Promo video on locale homepage stays muted (`data-force-muted`)
- [ ] No console errors from empty `ambient.mp3` / `jump.mp3` assets


Made with [Cursor](https://cursor.com)