### PR TITLE
fix(ciromap): link landing page to live App Store listing

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -6,7 +6,10 @@ import FloatingSprites from '../../components/FloatingSprites';
 import { ProjectSpotlight } from '../../components/ProjectSpotlight';
 import { JsonLd } from '../../components/seo/JsonLd';
 import { birdLinesWatchPath } from '../../lib/birdLinesVideo';
+import { getAppBySlug } from '../../lib/apps';
 import { SITE_URL, baseMetadata, buildHomeGraph, buildLanguageAlternates, isSupportedLocale, LOCALE_OG } from '../../lib/seo';
+
+const CIRO_MAP_APP_STORE_URL = getAppBySlug('ciromap')!.appStoreUrl;
 
 type Lang = 'en' | 'it' | 'ru';
 
@@ -79,8 +82,8 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     ciromapSubtitle: 'Cirò Marina travel guide',
     ciromapDescription:
       'An iOS travel guide for Cirò Marina, Calabria: discover nearby places, routes, categories, and a private loyalty wallet.',
-    ciromapStatus: 'Status: iOS · App Store soon',
-    ciromapCTA: 'Explore Ciro.Map',
+    ciromapStatus: 'Status: Live on the App Store',
+    ciromapCTA: 'Download on App Store',
   },
   it: {
     title: 'AZUMBO — Studio Giochi Indie',
@@ -144,8 +147,8 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     ciromapSubtitle: 'Guida di viaggio a Cirò Marina',
     ciromapDescription:
       'Guida iOS per Cirò Marina, Calabria: scopri luoghi vicini, percorsi, categorie e un wallet fedeltà privato.',
-    ciromapStatus: 'Stato: iOS · App Store a breve',
-    ciromapCTA: 'Scopri Ciro.Map',
+    ciromapStatus: 'Stato: Live su App Store',
+    ciromapCTA: 'Scarica su App Store',
   },
   ru: {
     title: 'AZUMBO — инди-студия игр',
@@ -209,8 +212,8 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     ciromapSubtitle: 'Путеводитель по Cirò Marina',
     ciromapDescription:
       'iOS-гид по Cirò Marina, Калабрия: места рядом, маршруты, категории и приватный wallet для карт лояльности.',
-    ciromapStatus: 'Статус: iOS · скоро в App Store',
-    ciromapCTA: 'Смотреть Ciro.Map',
+    ciromapStatus: 'Статус: В App Store',
+    ciromapCTA: 'Скачать в App Store',
   }
 };
 
@@ -460,7 +463,8 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
             description={t.ciromapDescription}
             status={t.ciromapStatus}
             ctaLabel={t.ciromapCTA}
-            ctaHref="/ciromap"
+            ctaHref={CIRO_MAP_APP_STORE_URL}
+            external
             visual={
               <Link
                 href="/ciromap"

--- a/app/ciromap/ciromap.module.css
+++ b/app/ciromap/ciromap.module.css
@@ -49,6 +49,6 @@
 .primaryCta, .secondaryCta { display:inline-flex; align-items:center; justify-content:center; border-radius:999px; padding:12px 18px; font-weight:800; text-decoration:none; }
 .primaryCta { background:#1c1c1e; color:#fff; }
 .secondaryCta { border:1px solid rgba(28,28,30,.12); color:#1c1c1e; background:rgba(255,255,255,.38); }
-.badge { display:inline-flex; border:1px dashed rgba(28,28,30,.26); border-radius:14px; padding:10px 14px; color:rgba(60,60,67,.72); font-weight:700; }
+.storeMeta { margin-top: 16px; font-size: 13px; color: rgba(60,60,67,.58); }
 .footer { position:relative; z-index:1; max-width:920px; margin: 0 auto; padding: 12px 20px 42px; text-align:center; color: rgba(60,60,67,.62); font-size:14px; }
 @media (max-width: 640px) { .headerInner { align-items:flex-start; flex-direction:column; } .nav { justify-content:flex-start; } .metaGrid { grid-template-columns:1fr; } }

--- a/app/ciromap/components.tsx
+++ b/app/ciromap/components.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import styles from './ciromap.module.css';
+
+import { apps, CONTACT_EMAIL as STUDIO_CONTACT_EMAIL } from '../../lib/apps';
+
+export const CONTACT_EMAIL = STUDIO_CONTACT_EMAIL;
+
+export const CIRO_MAP = apps.find((app) => app.slug === 'ciromap')!;
+export const APP_STORE_URL = CIRO_MAP.appStoreUrl;
+
+export function AppStoreButton({ compact = false }: { compact?: boolean }) {
+  return (
+    <a
+      className={styles.primaryCta}
+      href={APP_STORE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Download Ciro.Map on the App Store"
+    >
+      {compact ? 'App Store' : 'Download on the App Store'}
+    </a>
+  );
+}
+
+export function CiroMapNav() {
+  return (
+    <header className={styles.header}>
+      <div className={styles.headerInner}>
+        <Link href="/ciromap" className={styles.brand}>
+          <span>Ciro.Map</span>
+        </Link>
+        <nav className={styles.nav} aria-label="Ciro.Map navigation">
+          <Link href="/en">Azumbo</Link>
+          <Link href="/ciromap/privacy">Privacy Policy</Link>
+          <a href={`mailto:${CONTACT_EMAIL}`}>Contact</a>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/app/ciromap/page.tsx
+++ b/app/ciromap/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
+import { AppStoreButton, CIRO_MAP } from './components';
 import styles from './ciromap.module.css';
 import { SITE_URL } from '../../lib/seo';
 
@@ -8,11 +9,12 @@ const OG_IMAGE = `${SITE_URL}/ciromap/og-ciromap.jpg`;
 
 export const metadata: Metadata = {
   title: 'Ciro.Map — Cirò Marina Travel Guide',
-  description: 'Ciro.Map is an iOS travel guide for Cirò Marina, Calabria, Italy, with maps, points of interest, routes, and a loyalty wallet.',
+  description:
+    'Ciro.Map is an iOS travel guide for Cirò Marina, Calabria, Italy — available on the App Store with maps, points of interest, routes, and a loyalty wallet.',
   alternates: { canonical: `${SITE_URL}/ciromap` },
   openGraph: {
     title: 'Ciro.Map — Cirò Marina Travel Guide',
-    description: 'Maps, points of interest, routes, and a loyalty wallet for Cirò Marina, Calabria.',
+    description: 'Maps, points of interest, routes, and a loyalty wallet for Cirò Marina, Calabria. Download on the App Store.',
     url: `${SITE_URL}/ciromap`,
     siteName: 'AZUMBO',
     type: 'website',
@@ -59,26 +61,45 @@ export default function CiroMapLandingPage() {
             priority
             aria-hidden
           />
-          <p className={styles.kicker}>Azumbo · Chic Escape</p>
+          <p className={styles.kicker}>Azumbo · Chic Escape · iOS</p>
           <h1 className={styles.title}>Ciro.Map</h1>
-          <p className={styles.subtitle}>A polished iOS travel guide for Cirò Marina, Calabria, with nearby places, routes, categories, and a private loyalty wallet.</p>
+          <p className={styles.subtitle}>
+            A polished iOS travel guide for Cirò Marina, Calabria, with nearby places, routes, categories, and a private loyalty wallet.
+          </p>
           <div className={styles.ctaRow}>
-            <Link className={styles.primaryCta} href="/ciromap/privacy">Read Privacy Policy</Link>
-            <span className={styles.badge} aria-label="App Store badge placeholder">Download on the App Store · Soon</span>
+            <AppStoreButton />
+            <Link className={styles.secondaryCta} href="/ciromap/privacy">
+              Read Privacy Policy
+            </Link>
           </div>
+          <p className={styles.storeMeta}>
+            Available on the App Store · App ID {CIRO_MAP.appStoreId} · Bundle ID {CIRO_MAP.bundleId}
+          </p>
         </section>
         <section className={styles.card} aria-labelledby="features-title">
           <p className={styles.kicker}>iOS 17+ · UIKit · MapKit</p>
-          <h2 id="features-title" className="mt-3 text-3xl font-extrabold tracking-tight">Cirò Marina, beautifully mapped.</h2>
+          <h2 id="features-title" className="mt-3 text-3xl font-extrabold tracking-tight">
+            Cirò Marina, beautifully mapped.
+          </h2>
           <div className={styles.metaGrid}>
-            <div className={styles.metaItem}><strong>Discover</strong>Firebase-powered points of interest with categories and distance sorting.</div>
-            <div className={styles.metaItem}><strong>Navigate</strong>Open routes from the map using location only when you grant access.</div>
-            <div className={styles.metaItem}><strong>Wallet</strong>Store loyalty barcodes in Keychain and covers locally on your device.</div>
-            <div className={styles.metaItem}><strong>Free tier</strong>AdMob interstitials can be removed with a one-time StoreKit 2 purchase.</div>
+            <div className={styles.metaItem}>
+              <strong>Discover</strong>Firebase-powered points of interest with categories and distance sorting.
+            </div>
+            <div className={styles.metaItem}>
+              <strong>Navigate</strong>Open routes from the map using location only when you grant access.
+            </div>
+            <div className={styles.metaItem}>
+              <strong>Wallet</strong>Store loyalty barcodes in Keychain and covers locally on your device.
+            </div>
+            <div className={styles.metaItem}>
+              <strong>Free tier</strong>AdMob interstitials can be removed with a one-time StoreKit 2 purchase.
+            </div>
           </div>
         </section>
       </main>
-      <footer className={styles.footer}>© 2026 Azumbo · <Link href="/ciromap/privacy">Ciro.Map Privacy</Link></footer>
+      <footer className={styles.footer}>
+        © 2026 Azumbo · <Link href="/ciromap/privacy">Ciro.Map Privacy</Link>
+      </footer>
     </div>
   );
 }

--- a/lib/apps.ts
+++ b/lib/apps.ts
@@ -27,6 +27,19 @@ export const apps: StudioApp[] = [
     privacyPath: '/lapasta/privacy',
     supportPath: '/lapasta/support',
   },
+  {
+    name: 'Ciro.Map',
+    slug: 'ciromap',
+    appStoreId: '6776004922',
+    appStoreUrl: 'https://apps.apple.com/us/app/ciro-map/id6776004922',
+    bundleId: 'com.azumbo.ciromap',
+    description:
+      'A polished iOS travel guide for Cirò Marina, Calabria, with nearby places, routes, categories, and a private loyalty wallet.',
+    icon: '🗺️',
+    tagline: 'Cirò Marina travel guide',
+    privacyPath: '/ciromap/privacy',
+    supportPath: '/ciromap',
+  },
 ];
 
 export function getAppBySlug(slug: string) {


### PR DESCRIPTION
## Summary
- Add Ciro.Map to the shared app registry with App Store ID `6776004922`.
- Replace the "App Store · Soon" placeholder on `/ciromap` with a live download button.
- Update homepage Ciro.Map spotlight status and CTA to point to the App Store listing.

## Test plan
- [ ] Open `/ciromap` and confirm "Download on the App Store" links to https://apps.apple.com/us/app/ciro-map/id6776004922
- [ ] Confirm Privacy Policy remains accessible as secondary CTA
- [ ] Check homepage Ciro.Map block shows "Live on the App Store" and external download CTA


Made with [Cursor](https://cursor.com)