### PR TITLE
Improve multilingual SEO and AI discoverability

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -7,6 +7,7 @@ import { ProjectSpotlight } from '../../components/ProjectSpotlight';
 import { JsonLd } from '../../components/seo/JsonLd';
 import { birdLinesWatchPath } from '../../lib/birdLinesVideo';
 import { getAppBySlug } from '../../lib/apps';
+import { HOME_BLUF, HOME_FAQ } from '../../lib/homeFaq';
 import { SITE_URL, baseMetadata, buildHomeGraph, buildLanguageAlternates, isSupportedLocale, LOCALE_OG } from '../../lib/seo';
 
 const CIRO_MAP_APP_STORE_URL = getAppBySlug('ciromap')!.appStoreUrl;
@@ -64,6 +65,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     videoLinkLabel: 'Watch trailer',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
+    faqTitle: 'FAQ',
     pressLine: 'For publishers & press: azumbogames@gmail.com',
     ciroPrivacy: 'Ciro.Map Privacy',
     lapastaTitle: 'La Pasta: 60s Challenge',
@@ -129,6 +131,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     videoLinkLabel: 'Guarda il trailer',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
+    faqTitle: 'Domande frequenti',
     pressLine: 'Per editori e stampa: azumbogames@gmail.com',
     ciroPrivacy: 'Privacy Ciro.Map',
     lapastaTitle: 'La Pasta: 60s Challenge',
@@ -194,6 +197,7 @@ const STRINGS: Record<Lang, Record<string, string>> = {
     videoLinkLabel: 'Смотреть трейлер',
     valuesTitle: 'Studio Roadmap',
     valuesItems: 'Minimalism · Mental Resilience · Intelligent Humor',
+    faqTitle: 'Частые вопросы',
     pressLine: 'Для издателей и прессы: azumbogames@gmail.com',
     ciroPrivacy: 'Конфиденциальность Ciro.Map',
     lapastaTitle: 'La Pasta: 60s Challenge',
@@ -324,7 +328,10 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
         <FloatingSprites />
         <p className="text-xs uppercase tracking-[0.2em] text-neutral-500">{t.kicker}</p>
         <h1 className="mt-5 text-5xl font-black leading-tight sm:text-7xl">{t.title}</h1>
-        <p className="mt-6 max-w-2xl text-lg leading-relaxed text-neutral-600 dark:text-neutral-300">{t.subtitle}</p>
+        <p className="mt-6 max-w-2xl text-lg font-medium leading-relaxed text-neutral-800 dark:text-neutral-200">
+          {HOME_BLUF[routeLang]}
+        </p>
+        <p className="mt-4 max-w-2xl text-lg leading-relaxed text-neutral-600 dark:text-neutral-300">{t.subtitle}</p>
         <div className="mt-8">
           <a href="mailto:azumbogames@gmail.com" className="inline-block rounded-xl border border-neutral-300 px-6 py-3 font-medium transition hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900">
             {t.ctaContact}
@@ -487,6 +494,18 @@ export default async function AzumboLanding({ params }: { params: Promise<{ loca
           <p className="text-xs uppercase tracking-[0.16em] text-neutral-500 dark:text-neutral-400">{t.valuesTitle}</p>
           <p className="mt-2 text-base font-medium text-neutral-800 dark:text-neutral-100">{t.valuesItems}</p>
         </article>
+      </section>
+
+      <section id="faq" className="mx-auto max-w-5xl px-4 py-16">
+        <h2 className="text-3xl font-bold">{t.faqTitle}</h2>
+        <dl className="mt-8 space-y-4">
+          {HOME_FAQ[routeLang].map((faq) => (
+            <div key={faq.question} className="rounded-2xl border border-neutral-200 p-5 dark:border-neutral-800">
+              <dt className="font-semibold">{faq.question}</dt>
+              <dd className="mt-2 text-neutral-600 dark:text-neutral-300">{faq.answer}</dd>
+            </div>
+          ))}
+        </dl>
       </section>
 
       <footer id="contact" className="border-t border-neutral-200 py-10 text-center dark:border-neutral-800">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata, Viewport } from 'next';
+import { headers } from 'next/headers';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import GameFX from '../components/GameFX';
-import { SITE_URL, baseMetadata } from '../lib/seo';
+import { LOCALE_REQUEST_HEADER, SITE_URL, baseMetadata, resolveHtmlLang } from '../lib/seo';
 
 const inter = Inter({
   subsets: ['latin', 'cyrillic'],
@@ -67,8 +68,10 @@ export const viewport: Viewport = {
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  const htmlLang = resolveHtmlLang(headers().get(LOCALE_REQUEST_HEADER));
+
   return (
-    <html lang="en-US" className="h-full">
+    <html lang={htmlLang} className="h-full">
       <body
         className={`${inter.variable} min-h-full bg-white text-neutral-900 antialiased dark:bg-neutral-950 dark:text-neutral-100`}
       >

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,40 @@
+import { SITE_URL } from '../../lib/seo';
+
+const LLMS_TXT = `# AZUMBO
+> Indie game studio building mobile and Nintendo Switch games from Calabria, Italy.
+
+Primary site: ${SITE_URL}
+Languages: English (/en), Italian (/it), Russian (/ru)
+
+## Localized homepages
+- ${SITE_URL}/en
+- ${SITE_URL}/it
+- ${SITE_URL}/ru
+
+## Studio projects
+- Bird Lines (match-3, in development): ${SITE_URL}/en/videos/bird-lines
+- La Pasta: 60s Challenge (iOS, live): ${SITE_URL}/lapasta
+- Ciro.Map (iOS travel guide, live): ${SITE_URL}/ciromap
+- Azumbox (mobile game concept): ${SITE_URL}/azumbox
+
+## Services
+- Prototype sprints, publishing, UA support, Nintendo Switch porting
+- Contact: azumbogames@gmail.com
+
+## Legal and policies
+- Ciro.Map privacy: ${SITE_URL}/ciromap/privacy
+- La Pasta privacy: ${SITE_URL}/lapasta/privacy
+
+## Crawling
+- Sitemap: ${SITE_URL}/sitemap.xml
+- Robots: ${SITE_URL}/robots.txt
+`;
+
+export function GET() {
+  return new Response(LLMS_TXT, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,7 +8,7 @@ import {
   INDEXABLE_ROUTES,
 } from '../lib/seo';
 
-const LAST_MODIFIED = new Date('2026-07-04T00:00:00.000Z');
+const LAST_MODIFIED = new Date('2026-07-05T00:00:00.000Z');
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const localeHomepages = SUPPORTED_LOCALES.map((locale) => {

--- a/lib/homeFaq.ts
+++ b/lib/homeFaq.ts
@@ -1,0 +1,63 @@
+import type { Locale } from './seo';
+
+type HomeFaqItem = { question: string; answer: string };
+
+export const HOME_BLUF: Record<Locale, string> = {
+  en: 'AZUMBO is an indie game studio building mobile and Nintendo Switch games — including Bird Lines, La Pasta, Ciro.Map, and Azumbox — with prototype, publishing, and porting services.',
+  it: 'AZUMBO è uno studio indie che sviluppa giochi mobile e per Nintendo Switch — tra cui Bird Lines, La Pasta, Ciro.Map e Azumbox — con servizi di prototipazione, publishing e porting.',
+  ru: 'AZUMBO — инди-студия мобильных игр и портов на Nintendo Switch: Bird Lines, La Pasta, Ciro.Map и Azumbox, а также услуги прототипирования, паблишинга и портирования.',
+};
+
+export const HOME_FAQ: Record<Locale, HomeFaqItem[]> = {
+  en: [
+    {
+      question: 'What is AZUMBO?',
+      answer:
+        'AZUMBO is an indie game studio focused on mobile-first casual games, Nintendo Switch ports, and rapid publishing for Android and iOS.',
+    },
+    {
+      question: 'Which languages does AZUMBO support?',
+      answer:
+        'The AZUMBO website is available in English, Italian, and Russian at /en, /it, and /ru with matching hreflang signals for search engines and AI crawlers.',
+    },
+    {
+      question: 'What projects does AZUMBO publish?',
+      answer:
+        'Current studio projects include Bird Lines, La Pasta: 60s Challenge, Ciro.Map, and Azumbox, plus classic web arcade demos such as Frogger, Pac-Man, and Space Invaders.',
+    },
+  ],
+  it: [
+    {
+      question: "Cos'è AZUMBO?",
+      answer:
+        'AZUMBO è uno studio indie di giochi mobile-first, porting su Nintendo Switch e pubblicazione rapida per Android e iOS.',
+    },
+    {
+      question: 'Quali lingue supporta AZUMBO?',
+      answer:
+        'Il sito AZUMBO è disponibile in inglese, italiano e russo su /en, /it e /ru con segnali hreflang per motori di ricerca e crawler AI.',
+    },
+    {
+      question: 'Quali progetti pubblica AZUMBO?',
+      answer:
+        'I progetti dello studio includono Bird Lines, La Pasta: 60s Challenge, Ciro.Map e Azumbox, oltre a demo arcade web come Frogger, Pac-Man e Space Invaders.',
+    },
+  ],
+  ru: [
+    {
+      question: 'Что такое AZUMBO?',
+      answer:
+        'AZUMBO — инди-студия мобильных игр, портов на Nintendo Switch и быстрого паблишинга для Android и iOS.',
+    },
+    {
+      question: 'На каких языках доступен сайт AZUMBO?',
+      answer:
+        'Сайт AZUMBO доступен на английском, итальянском и русском по адресам /en, /it и /ru с корректными hreflang-сигналами для поисковиков и AI-краулеров.',
+    },
+    {
+      question: 'Какие проекты есть у AZUMBO?',
+      answer:
+        'Среди проектов студии — Bird Lines, La Pasta: 60s Challenge, Ciro.Map и Azumbox, а также веб-аркады Frogger, Pac-Man и Space Invaders.',
+    },
+  ],
+};

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
+import { HOME_FAQ } from './homeFaq';
 
 export const SITE_URL = 'https://azumbo.vercel.app';
 export const PRIMARY_HOST = 'azumbo.vercel.app';
 export const SUPPORTED_LOCALES = ['en', 'it', 'ru'] as const;
 export const DEFAULT_LOCALE = 'en';
+export const LOCALE_REQUEST_HEADER = 'x-azumbo-locale';
 
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
@@ -155,6 +157,13 @@ export function buildPageMetadata({
   };
 }
 
+export function resolveHtmlLang(locale: string | null | undefined): string {
+  if (locale && isSupportedLocale(locale)) {
+    return LOCALE_HTML_LANG[locale];
+  }
+  return LOCALE_HTML_LANG[DEFAULT_LOCALE];
+}
+
 export function buildHomeGraph(locale: Locale) {
   const pageUrl = buildCanonical(`/${locale}`);
 
@@ -172,21 +181,39 @@ export function buildHomeGraph(locale: Locale) {
         },
         email: 'azumbogames@gmail.com',
         sameAs: [...ORGANIZATION_SAME_AS],
-        areaServed: {
-          '@type': 'Country',
-          name: 'United States',
-        },
         knowsLanguage: ['en-US', 'it-IT', 'ru-RU'],
       },
       {
         '@type': 'WebSite',
         '@id': WEBSITE_ID,
-        url: pageUrl,
+        url: SITE_URL,
         name: 'AZUMBO',
         description:
-          'Indie game studio building mobile and Nintendo Switch games for global audiences with US-first English content.',
+          'Indie game studio building mobile and Nintendo Switch games for English, Italian, and Russian audiences.',
         publisher: { '@id': ORGANIZATION_ID },
+        inLanguage: ['en-US', 'it-IT', 'ru-RU'],
+      },
+      {
+        '@type': 'WebPage',
+        '@id': `${pageUrl}#webpage`,
+        url: pageUrl,
+        name: 'AZUMBO',
         inLanguage: LOCALE_HTML_LANG[locale],
+        isPartOf: { '@id': WEBSITE_ID },
+        about: { '@id': ORGANIZATION_ID },
+      },
+      {
+        '@type': 'FAQPage',
+        '@id': `${pageUrl}#faq`,
+        inLanguage: LOCALE_HTML_LANG[locale],
+        mainEntity: HOME_FAQ[locale].map((faq) => ({
+          '@type': 'Question',
+          name: faq.question,
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: faq.answer,
+          },
+        })),
       },
     ],
   };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-import { DEFAULT_LOCALE, PRIMARY_HOST, SUPPORTED_LOCALES } from './lib/seo';
+import { DEFAULT_LOCALE, LOCALE_REQUEST_HEADER, PRIMARY_HOST, SUPPORTED_LOCALES } from './lib/seo';
 
 function getPreferredLocale(request: NextRequest): string {
   const cookieLocale = request.cookies.get('azumbo_locale')?.value;
@@ -61,7 +61,11 @@ export function middleware(request: NextRequest) {
   const localeMatch = pathname.match(/^\/(en|ru|it)(\/.*)?$/);
   if (localeMatch) {
     const locale = localeMatch[1];
-    const response = NextResponse.next();
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set(LOCALE_REQUEST_HEADER, locale);
+    const response = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
     response.cookies.set('azumbo_locale', locale, {
       path: '/',
       sameSite: 'lax',

--- a/scripts/seo-live-check.sh
+++ b/scripts/seo-live-check.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 BASE_URL="${1:-https://azumbo.vercel.app}"
 
-urls=("/" "/en" "/ru" "/it" "/en/" "/sitemap.xml" "/robots.txt")
+urls=("/" "/en" "/ru" "/it" "/en/" "/sitemap.xml" "/robots.txt" "/llms.txt")
 
 for p in "${urls[@]}"; do
   echo "===== $BASE_URL$p ====="
@@ -24,6 +24,12 @@ echo "$html" | grep -q 'rel="canonical" href="https://azumbo.vercel.app/en"' && 
 
 for loc in en ru it; do
   html="$(curl -sS -L "$BASE_URL/$loc")"
+  case "$loc" in
+    en) expected_lang='en-US' ;;
+    ru) expected_lang='ru-RU' ;;
+    it) expected_lang='it-IT' ;;
+  esac
+  echo "$html" | grep -q "<html lang=\"$expected_lang\"" && echo "OK: /$loc html lang=$expected_lang" || { echo "FAIL: /$loc html lang not $expected_lang"; exit 1; }
   if echo "$html" | grep -q '"@type":"VideoObject"'; then
     echo "FAIL: VideoObject found on /$loc homepage"
     exit 1
@@ -33,6 +39,19 @@ for loc in en ru it; do
     exit 1
   fi
   echo "OK: /$loc homepage has no VideoObject or embedded video"
+done
+
+echo "===== llms.txt AI discovery ====="
+llms="$(curl -sS "$BASE_URL/llms.txt")"
+echo "$llms" | grep -q '/en' && echo "OK: llms.txt lists /en" || { echo "FAIL: llms.txt missing /en"; exit 1; }
+echo "$llms" | grep -q '/ru' && echo "OK: llms.txt lists /ru" || { echo "FAIL: llms.txt missing /ru"; exit 1; }
+echo "$llms" | grep -q '/it' && echo "OK: llms.txt lists /it" || { echo "FAIL: llms.txt missing /it"; exit 1; }
+echo "$llms" | grep -q 'Bird Lines' && echo "OK: llms.txt lists studio projects" || { echo "FAIL: llms.txt missing projects"; exit 1; }
+
+echo "===== FAQ schema on homepages ====="
+for loc in en ru it; do
+  html="$(curl -sS -L "$BASE_URL/$loc")"
+  echo "$html" | grep -q '"@type":"FAQPage"' && echo "OK: FAQPage schema on /$loc" || { echo "FAIL: FAQPage missing on /$loc"; exit 1; }
 done
 
 echo "===== Bird Lines watch page (Google video indexing) ====="

--- a/scripts/seo-smoke.mjs
+++ b/scripts/seo-smoke.mjs
@@ -8,6 +8,8 @@ const watchPage = fs.readFileSync('app/[locale]/videos/bird-lines/page.tsx', 'ut
 const birdLinesVideo = fs.readFileSync('lib/birdLinesVideo.ts', 'utf8');
 const rootLayout = fs.readFileSync('app/layout.tsx', 'utf8');
 const jsonLd = fs.readFileSync('components/seo/JsonLd.tsx', 'utf8');
+const middlewareTs = fs.readFileSync('middleware.ts', 'utf8');
+const homeFaq = fs.readFileSync('lib/homeFaq.ts', 'utf8');
 const rootPage = fs.readFileSync('app/page.tsx', 'utf8');
 
 function assert(cond, msg) {
@@ -38,7 +40,14 @@ assert(watchPage.includes('buildBirdLinesWatchGraph'), 'watch page must emit Vid
 assert(birdLinesVideo.includes('FAQPage'), 'watch page graph must include FAQ schema');
 assert(birdLinesVideo.includes('width: BIRD_LINES_WIDTH'), 'VideoObject must include width');
 assert(birdLinesVideo.includes('publisher:'), 'VideoObject must include publisher');
-assert(rootLayout.includes('lang="en-US"'), 'root html lang must target US English');
+assert(seoTs.includes('FAQPage'), 'homepage graph must include FAQ schema');
+assert(seoTs.includes('resolveHtmlLang'), 'html lang resolver missing');
+assert(middlewareTs.includes('LOCALE_REQUEST_HEADER'), 'middleware must pass locale request header');
+assert(fs.existsSync('app/llms.txt/route.ts'), 'llms.txt route missing');
+assert(homeFaq.includes('HOME_BLUF'), 'homepage BLUF copy missing');
+assert(localePage.includes('HOME_FAQ'), 'homepage must render visible FAQ section');
+assert(rootLayout.includes('resolveHtmlLang'), 'root layout must resolve html lang dynamically');
+assert(!rootLayout.includes('lang="en-US"'), 'root layout must not hardcode en-US html lang');
 assert(rootLayout.includes("card: 'summary_large_image'"), 'twitter card metadata missing');
 assert(!jsonLd.includes("'use client'"), 'JsonLd must render on the server for crawlers');
 assert(rootPage.includes("redirect('/en')"), 'root page must redirect to /en canonical locale');


### PR DESCRIPTION
## Summary
- Fix `html lang` per locale (`en-US`, `ru-RU`, `it-IT`) via middleware header + dynamic root layout
- Add BLUF copy and visible FAQ sections on EN/RU/IT homepages with `FAQPage` schema in `buildHomeGraph`
- Add `/llms.txt` for AI crawler discovery of localized homepages and studio projects
- Extend `seo-smoke` and `seo-live-check` for lang, FAQ schema, and llms.txt

## Test plan
- [x] `npm run seo:smoke`
- [x] `npm run build`
- [ ] `npm run seo:live` after deploy
- [ ] Request indexing in GSC for `/en`, `/ru`, `/it`


Made with [Cursor](https://cursor.com)